### PR TITLE
Add repository, github_project, and version fields to Project struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "nyx"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyx"
-version = "0.9.5"
+version = "0.9.6"
 edition = "2021"
 authors = ["Elouan DA COSTA PEIXOTO <elouandacostapeixoto@gmail.com>"]
 description = "A CLI tool for managing your system."

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -15,6 +15,8 @@ pub struct Project {
     pub name: String,
     pub tech: String,
     pub location: String,
+    pub repository: String,
+    pub github_project: String,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -159,6 +161,8 @@ fn add_project_to_list(tech: &String) {
         name: (app_name.to_string()),
         tech: (tech.to_string()),
         location: (current_dir),
+        repository: "No repository specified".to_string(),
+        github_project: "No github project specified".to_string(),
     };
     projects.push(new_app.clone());
     let updated_data = Data { project: projects };

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -17,6 +17,7 @@ pub struct Project {
     pub location: String,
     pub repository: String,
     pub github_project: String,
+    pub version: String,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -156,13 +157,46 @@ fn add_project_to_list(tech: &String) {
     let current_dir = utils::get_current_path();
     let app_name = current_dir.split("/").last().unwrap();
     let app_id = &app_name[..3];
+    let mut repository_user_input: String;
+    repository_user_input = utils::prompt_message(
+        "Enter the url of the github's repository of the project: ".to_string(),
+        "Failed to get the user input".to_string(),
+    );
+
+    if repository_user_input == "".to_string() {
+        repository_user_input = "No repository specified".to_string()
+    }
+
+    let mut github_project: String;
+
+    github_project = utils::prompt_message(
+        "Enter the url of the github project: ".to_string(),
+        "Error getting the user input".to_string(),
+    );
+
+    if github_project == "".to_string() {
+        github_project = "No github project specified".to_string()
+    }
+
+    let mut version: String;
+
+    version = utils::prompt_message(
+        "Enter the version of the project: ".to_string(),
+        "Error getting the user input".to_string(),
+    );
+
+    if version == "".to_string() {
+        version = "0.1.0".to_string();
+    }
+
     let new_app: Project = Project {
         id: (app_id.to_string().to_lowercase()),
         name: (app_name.to_string()),
         tech: (tech.to_string()),
         location: (current_dir),
-        repository: "No repository specified".to_string(),
-        github_project: "No github project specified".to_string(),
+        repository: repository_user_input,
+        github_project: github_project,
+        version: version,
     };
     projects.push(new_app.clone());
     let updated_data = Data { project: projects };

--- a/src/projects/update/mod.rs
+++ b/src/projects/update/mod.rs
@@ -47,6 +47,9 @@ fn update_select_properties(project: projects::Project, property: String) -> pro
         property if property == "name" => update_project_name(project),
         property if property == "tech" => update_project_tech(project),
         property if property == "location" => update_project_location(project),
+        property if property == "repository" => update_project_repository(project),
+        property if property == "github_project" => update_project_github_project(project),
+        property if property == "version" => update_project_version(project),
         _ => {
             println!("no property matching detected.");
             project
@@ -126,6 +129,65 @@ fn update_project_tech(project: projects::Project) -> projects::Project {
         repository: project.repository,
         github_project: project.github_project,
         version: project.version,
+    };
+    return update_project;
+}
+
+fn update_project_repository(project: projects::Project) -> projects::Project {
+    let new_url = utils::prompt_message(
+        "Enter the new project's repository: ".to_string(),
+        "Error getting the new project's repository".to_string(),
+    );
+    let re = Regex::new(r"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)").unwrap();
+    if !re.is_match(&new_url) {
+        println!("{}", "The url is not correct. Please enter a correct url.")
+    }
+    let update_project: projects::Project = projects::Project {
+        id: project.id,
+        name: project.name,
+        tech: project.tech,
+        location: project.location,
+        repository: new_url,
+        github_project: project.github_project,
+        version: project.version,
+    };
+    return update_project;
+}
+
+fn update_project_github_project(project: projects::Project) -> projects::Project {
+    let new_url = utils::prompt_message(
+        "Enter the new project's github project: ".to_string(),
+        "Error getting the new project's github project".to_string(),
+    );
+    let re = Regex::new(r"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)").unwrap();
+    if !re.is_match(&new_url) {
+        println!("{}", "The url is not correct. Please enter a correct url.")
+    }
+    let update_project: projects::Project = projects::Project {
+        id: project.id,
+        name: project.name,
+        tech: project.tech,
+        location: project.location,
+        repository: project.repository,
+        github_project: new_url,
+        version: project.version,
+    };
+    return update_project;
+}
+
+fn update_project_version(project: projects::Project) -> projects::Project {
+    let new_version = utils::prompt_message(
+        "Enter the new project's version: ".to_string(),
+        "Error getting the new project's version".to_string(),
+    );
+    let update_project: projects::Project = projects::Project {
+        id: project.id,
+        name: project.name,
+        tech: project.tech,
+        location: project.location,
+        repository: project.repository,
+        github_project: project.github_project,
+        version: new_version,
     };
     return update_project;
 }

--- a/src/projects/update/mod.rs
+++ b/src/projects/update/mod.rs
@@ -31,6 +31,7 @@ pub fn update_project_properties() {
             location: app.location,
             repository: app.repository,
             github_project: app.github_project,
+            version: app.version,
         };
         let updated_project = update_select_properties(current_selected_project, property);
         projects.push(updated_project);
@@ -65,6 +66,7 @@ fn update_project_id(project: projects::Project) -> projects::Project {
         location: project.location,
         repository: project.repository,
         github_project: project.github_project,
+        version: project.version,
     };
     return update_project;
 }
@@ -81,6 +83,7 @@ fn update_project_name(project: projects::Project) -> projects::Project {
         location: project.location,
         repository: project.repository,
         github_project: project.github_project,
+        version: project.version,
     };
     return update_project;
 }
@@ -104,6 +107,7 @@ fn update_project_location(project: projects::Project) -> projects::Project {
         location: new_location,
         repository: project.repository,
         github_project: project.github_project,
+        version: project.version,
     };
     return update_project;
 }
@@ -121,6 +125,7 @@ fn update_project_tech(project: projects::Project) -> projects::Project {
         location: project.location,
         repository: project.repository,
         github_project: project.github_project,
+        version: project.version,
     };
     return update_project;
 }

--- a/src/projects/update/mod.rs
+++ b/src/projects/update/mod.rs
@@ -29,6 +29,8 @@ pub fn update_project_properties() {
             name: app.name,
             tech: app.tech,
             location: app.location,
+            repository: app.repository,
+            github_project: app.github_project,
         };
         let updated_project = update_select_properties(current_selected_project, property);
         projects.push(updated_project);
@@ -61,6 +63,8 @@ fn update_project_id(project: projects::Project) -> projects::Project {
         name: project.name,
         tech: project.tech,
         location: project.location,
+        repository: project.repository,
+        github_project: project.github_project,
     };
     return update_project;
 }
@@ -75,6 +79,8 @@ fn update_project_name(project: projects::Project) -> projects::Project {
         name: new_name,
         tech: project.tech,
         location: project.location,
+        repository: project.repository,
+        github_project: project.github_project,
     };
     return update_project;
 }
@@ -96,6 +102,8 @@ fn update_project_location(project: projects::Project) -> projects::Project {
         name: project.name,
         tech: project.tech,
         location: new_location,
+        repository: project.repository,
+        github_project: project.github_project,
     };
     return update_project;
 }
@@ -111,6 +119,8 @@ fn update_project_tech(project: projects::Project) -> projects::Project {
         name: project.name,
         tech: new_tech,
         location: project.location,
+        repository: project.repository,
+        github_project: project.github_project,
     };
     return update_project;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -108,6 +108,9 @@ pub fn get_project_property() -> Vec<String> {
         "name".to_string(),
         "tech".to_string(),
         "location".to_string(),
+        "repository".to_string(),
+        "github_project".to_string(),
+        "version".to_string(),
     ];
     return options;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,6 +32,8 @@ pub fn get_app_vec() -> Vec<projects::Project> {
             name: app.name.clone(),
             tech: app.tech.clone(),
             location: app.location.clone(),
+            repository: app.repository.clone(),
+            github_project: app.github_project.clone(),
         });
     }
     return projects;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -34,6 +34,7 @@ pub fn get_app_vec() -> Vec<projects::Project> {
             location: app.location.clone(),
             repository: app.repository.clone(),
             github_project: app.github_project.clone(),
+            version: app.version.clone(),
         });
     }
     return projects;


### PR DESCRIPTION
Enhance the Project struct by adding fields for repository, GitHub project, and version. Update related functions and commands to support these new fields, ensuring proper handling during project creation and updates. Additionally, update the nyx version to 0.9.6.