### PR TITLE
Refactor the cleanup command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "nyx"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "bincode",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyx"
-version = "1.9.0"
+version = "1.10.0"
 edition = "2021"
 authors = ["Elouan DA COSTA PEIXOTO <elouandacostapeixoto@gmail.com>"]
 description = "A CLI tool for managing your projects."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyx"
-version = "1.8.1"
+version = "1.9.0"
 edition = "2021"
 authors = ["Elouan DA COSTA PEIXOTO <elouandacostapeixoto@gmail.com>"]
 description = "A CLI tool for managing your projects."

--- a/src/cleanup/mod.rs
+++ b/src/cleanup/mod.rs
@@ -48,7 +48,7 @@ pub fn choose_cleanup() {
 fn which_remove_files(choice: &str) {
     match choice {
         choice if choice == "Remove all docker unused files" => prune_docker_unused(),
-        // choice if choice == "Remove all projects build caches and files" => prune_project_unused(),
+        choice if choice == "Remove all projects build caches and files" => prune_project_unused(),
         _ => println!("please make a choice"),
     }
 }
@@ -108,27 +108,27 @@ fn prune_docker_unused() {
 // this function remove all build cache,
 // node_modules, bin folder content of the
 // project managed by nyx
-// fn prune_project_unused() {
-//     let projects = nxs::get_all_project();
-//     println!("Cleaning up all projects by removing dependency folders (node_modules), compiled files (dist), and executable binaries (bin) that are no longer needed.");
-//     for i in &projects {
-//         // Node.js
-//         let node_module_path = i.location.to_string() + "/node_modules";
-//         let nodejs_dist_path = i.location.to_string() + "/dist";
-//         lrncore::path::change_work_dir(&i.location);
-//         if lrncore::path::path_exists(&node_module_path) {
-//             utils::fsys::rm_command(node_module_path);
-//             utils::fsys::rm_command(nodejs_dist_path);
-//         }
-//         // Golang
-//         let bin_folder = i.location.to_string() + "/bin/";
-//         if lrncore::path::path_exists(&bin_folder) {
-//             utils::fsys::rm_command(bin_folder);
-//         }
-//         // Rust
-//         let target_folder = i.location.to_string() + "/target";
-//         if lrncore::path::path_exists(&target_folder) {
-//             utils::fsys::rm_command(target_folder);
-//         }
-//     }
-// }
+fn prune_project_unused() {
+    let projects = nxs::get_all_project_entries();
+    println!("Cleaning up all projects by removing dependency folders (node_modules), compiled files (dist), and executable binaries (bin) that are no longer needed.");
+    for i in &projects {
+        // Node.js
+        let node_module_path = i.location.to_string() + "/node_modules";
+        let nodejs_dist_path = i.location.to_string() + "/dist";
+        lrncore::path::change_work_dir(&i.location);
+        if lrncore::path::path_exists(&node_module_path) {
+            utils::fsys::rm_command(node_module_path);
+            utils::fsys::rm_command(nodejs_dist_path);
+        }
+        // Golang
+        let bin_folder = i.location.to_string() + "/bin/";
+        if lrncore::path::path_exists(&bin_folder) {
+            utils::fsys::rm_command(bin_folder);
+        }
+        // Rust
+        let target_folder = i.location.to_string() + "/target";
+        if lrncore::path::path_exists(&target_folder) {
+            utils::fsys::rm_command(target_folder);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,7 @@ use std::env;
 // Current version of NYX
 // if modified and then running update command it will replace
 // your current nyx installation with the newer version
-const VERSION: &'static str = "1.9.0";
-
+const VERSION: &'static str = "1.10.0";
 #[derive(Debug, Clone)]
 enum Commands {
     Init,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::env;
 // Current version of NYX
 // if modified and then running update command it will replace
 // your current nyx installation with the newer version
-const VERSION: &'static str = "1.8.1";
+const VERSION: &'static str = "1.9.0";
 
 #[derive(Debug, Clone)]
 enum Commands {

--- a/src/utils/fsys.rs
+++ b/src/utils/fsys.rs
@@ -4,6 +4,9 @@ This module provides utility functions for managing directory, file or using sys
 
 use crate::utils::exit;
 use crate::utils::Command;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::process::Stdio;
 
 pub fn create_dir(path: &str) {
     let mut mkdir = Command::new("mkdir")
@@ -18,9 +21,26 @@ pub fn create_dir(path: &str) {
 }
 
 pub fn rm_command(path: String) {
-    Command::new("rm")
+    let mut rm = Command::new("rm")
         .arg("-rf")
         .arg(path)
+        .stderr(Stdio::piped())
         .spawn()
         .expect("Failed to delete the directory of the project");
+    let stdout = rm.stderr.take().expect("Failed to get stdout");
+    let lines = BufReader::new(stdout).lines();
+    for line in lines {
+        if !line.as_ref().unwrap().is_empty() {
+            lrncore::logs::time_error_log(
+                "Error in the remove command. Check if you have the right to remove directories.",
+            );
+            println!("{}", line.unwrap());
+            exit(1);
+        }
+    }
+    let wait_rm = rm.wait().expect("Failed to wait rm command");
+    if !wait_rm.success() {
+        lrncore::logs::time_error_log("Failed to execute rm command");
+        exit(1);
+    }
 }


### PR DESCRIPTION
This pull request includes updates to the version of the project, re-enabling and refactoring a function for cleaning up project files, and adding error handling to the `rm_command` function.

### Version Update:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3): Updated the project version from `1.8.1` to `1.10.0`.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL18-R18): Updated the `VERSION` constant to match the new version `1.10.0`.

### Function Re-enabling and Refactoring:
* [`src/cleanup/mod.rs`](diffhunk://#diff-471923b99804c8ba07d5908b3ac7c11480a703ca31625c58e39e95cf472aa0e5L51-R51): Re-enabled the call to `prune_project_unused()` in the `which_remove_files` function.
* [`src/cleanup/mod.rs`](diffhunk://#diff-471923b99804c8ba07d5908b3ac7c11480a703ca31625c58e39e95cf472aa0e5L111-R134): Refactored the `prune_project_unused` function to use `nxs::get_all_project_entries()` and cleaned up the code for removing project files.

### Error Handling Improvements:
* [`src/utils/fsys.rs`](diffhunk://#diff-8377c064def3ace844beabcbbf0c26e7e650e9c788264241ad3037fde4a37c92L21-R45): Enhanced the `rm_command` function to include error handling by capturing and logging errors from the `rm` command's stderr output.
* [`src/utils/fsys.rs`](diffhunk://#diff-8377c064def3ace844beabcbbf0c26e7e650e9c788264241ad3037fde4a37c92R7-R9): Added necessary imports for `BufRead`, `BufReader`, and `Stdio` to support the new error handling in `rm_command`.…ariable