### PR TITLE
Add check before using rm command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "nyx"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "bincode",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "nyx"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "bincode",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyx"
-version = "1.10.2"
+version = "1.10.3"
 edition = "2021"
 authors = ["Elouan DA COSTA PEIXOTO <elouandacostapeixoto@gmail.com>"]
 description = "A CLI tool for managing your projects."

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::env;
 // Current version of NYX
 // if modified and then running update command it will replace
 // your current nyx installation with the newer version
-const VERSION: &'static str = "1.10.2";
+const VERSION: &'static str = "1.10.3";
 #[derive(Debug, Clone)]
 enum Commands {
     Init,

--- a/src/utils/fsys.rs
+++ b/src/utils/fsys.rs
@@ -21,6 +21,23 @@ pub fn create_dir(path: &str) {
 }
 
 pub fn rm_command(path: String) {
+    let forbidden_names = ["/", ".", ".."];
+    let forbidden_patterns = ['*', '?', '&', ';', '|', '`'];
+    if forbidden_names.contains(&path.as_str()) {
+        lrncore::logs::time_error_log("Input contains forbidden names.");
+        exit(1)
+    };
+
+    if path.chars().any(|c| forbidden_patterns.contains(&c)) {
+        lrncore::logs::time_error_log("Input contains forbidden patterns (*, ?, &, ;, |, `).");
+        exit(1)
+    }
+
+    if path.is_empty() {
+        lrncore::logs::time_error_log("Path is empty");
+        exit(1)
+    }
+
     let mut rm = Command::new("rm")
         .arg("-rf")
         .arg(path)

--- a/src/utils/fsys.rs
+++ b/src/utils/fsys.rs
@@ -1,6 +1,6 @@
 /*
-This module provides utility functions for managing directory, file or using system's file system.
-*/
+   This module provides utility functions for managing directory, file or using system's file system.
+   */
 
 use crate::utils::exit;
 use crate::utils::Command;
@@ -21,6 +21,11 @@ pub fn create_dir(path: &str) {
 }
 
 pub fn rm_command(path: String) {
+    if path.is_empty() {
+        lrncore::logs::time_error_log("Path is empty");
+        exit(1)
+    }
+
     let forbidden_names = ["/", ".", ".."];
     let forbidden_patterns = ['*', '?', '&', ';', '|', '`'];
     if forbidden_names.contains(&path.as_str()) {
@@ -30,11 +35,6 @@ pub fn rm_command(path: String) {
 
     if path.chars().any(|c| forbidden_patterns.contains(&c)) {
         lrncore::logs::time_error_log("Input contains forbidden patterns (*, ?, &, ;, |, `).");
-        exit(1)
-    }
-
-    if path.is_empty() {
-        lrncore::logs::time_error_log("Path is empty");
         exit(1)
     }
 


### PR DESCRIPTION
This pull request includes updates to the version of the `nyx` tool and adds input validation to the `rm_command` function to improve security.

Version update:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3): Updated the version of the `nyx` package from `1.10.2` to `1.10.3`.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL18-R18): Updated the `VERSION` constant to reflect the new version `1.10.3`.

Security improvements:

* [`src/utils/fsys.rs`](diffhunk://#diff-8377c064def3ace844beabcbbf0c26e7e650e9c788264241ad3037fde4a37c92R24-R40): Added input validation to the `rm_command` function to check for forbidden names (`"/", ".", ".."`) and patterns (`'*', '?', '&', ';', '|', '`'`) and to ensure the path is not empty before executing the `rm` command.