### PR TITLE
Add project open command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "nyx"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "bincode",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "nyx"
-version = "1.10.3"
+version = "1.11.0"
 dependencies = [
  "bincode",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyx"
-version = "1.10.3"
+version = "1.11.0"
 edition = "2021"
 authors = ["Elouan DA COSTA PEIXOTO <elouandacostapeixoto@gmail.com>"]
 description = "A CLI tool for managing your projects."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyx"
-version = "1.11.0"
+version = "1.12.0"
 edition = "2021"
 authors = ["Elouan DA COSTA PEIXOTO <elouandacostapeixoto@gmail.com>"]
 description = "A CLI tool for managing your projects."

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::env;
 // Current version of NYX
 // if modified and then running update command it will replace
 // your current nyx installation with the newer version
-const VERSION: &'static str = "1.10.3";
+const VERSION: &str = "1.11.0";
 #[derive(Debug, Clone)]
 enum Commands {
     Init,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::env;
 // Current version of NYX
 // if modified and then running update command it will replace
 // your current nyx installation with the newer version
-const VERSION: &str = "1.11.0";
+const VERSION: &str = "1.12.0";
 #[derive(Debug, Clone)]
 enum Commands {
     Init,

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -78,7 +78,16 @@ pub fn project_command() {
             let project_name = &args[3];
             new_project(project_name.to_string());
         }
-        "open" => open_editor(),
+        "open" => {
+            let project_name: String;
+            if args.len() <= 3 {
+                project_name = "".to_string();
+                open_editor(&project_name);
+            } else {
+                project_name = args[3].clone();
+                open_editor(&project_name);
+            } 
+        },        
         "add" => add_existing_project_to_list(),
         "list" => list_projects(),
         "delete" => select_remove_project(),

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -36,7 +36,7 @@ Options:
     -h, --help      Show this help message
 ";
 
-    return usage.to_string();
+    usage.to_string()
 }
 
 #[derive(Deserialize, Serialize, Debug, Tabled, Clone, PartialEq)]

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -16,13 +16,16 @@ use lrncore::usage_exit::command_usage;
 pub mod nxp;
 pub mod nxs;
 pub mod todo;
+pub mod open;
+use open::open_editor;
 
 pub fn project_help() -> String {
     let usage = r"
 Usage: nyx project [subcommand] [arguments] [options]
 
 Subcommands:
-    new        Create a new project
+    new         Create a new project
+    open        Open your editor in project location
     add         Add an existing project to the list
     list        List all projects
     delete      Remove a project from the list
@@ -75,6 +78,7 @@ pub fn project_command() {
             let project_name = &args[3];
             new_project(project_name.to_string());
         }
+        "open" => open_editor(),
         "add" => add_existing_project_to_list(),
         "list" => list_projects(),
         "delete" => select_remove_project(),

--- a/src/projects/open/mod.rs
+++ b/src/projects/open/mod.rs
@@ -2,11 +2,41 @@ use crate::projects::exit;
 use crate::utils;
 use lrncore::path::change_work_dir;
 use std::process::Command;
+use lrncore::usage_exit::command_usage;
+use std::env;
 
 use super::nxs;
 
+pub fn open_help() -> String {
+    let usage = r"
+Usage: nyx project open [args]
+
+Arguments:
+    <project-name>  Enter project name to quickly open your editor
+
+Options:
+
+    -h, --help      Show this help message
+    ";
+
+    usage.to_string()
+}
+
+
 pub fn open_editor(project: &str) {
     change_work_dir(&utils::env::get_nyx_env_var());
+    let args: Vec<String> = env::args().collect();
+    if let Some(arg) = args.iter().last() {
+        match arg.as_str().trim() {
+            "-h" => {
+                command_usage(&open_help());
+            }
+            "--help" => {
+                command_usage(&open_help());
+            }
+            _ => {}
+        }
+    }
     let mut user_input_project = project.to_string();
     if project.is_empty() {
         let app_name = utils::prompt_message(

--- a/src/projects/open/mod.rs
+++ b/src/projects/open/mod.rs
@@ -1,0 +1,27 @@
+use lrncore::path::change_work_dir;
+use crate::utils;
+use std::process::Command;
+use crate::projects::exit;
+
+use super::nxs;
+
+pub fn open_editor() {
+    change_work_dir(&utils::env::get_nyx_env_var());
+    let app_name = utils::prompt_message("Enter project name:".to_string(), "Failed to get user input".to_string());
+    let mut projects = nxs::get_all_project_entries();
+    let location: String;
+    if let Some(pos) = projects.iter().position(|app| app.name == app_name) {
+        let app = projects.remove(pos);
+        location = app.location;
+    } else {
+        lrncore::logs::error_log("Project not found");
+        exit(1);
+    }
+
+    let editor_var = utils::env::get_editor_env_var();
+        Command::new(editor_var)
+        .arg(&location)
+        .status()
+        .expect("Something went wrong");
+}
+

--- a/src/projects/open/mod.rs
+++ b/src/projects/open/mod.rs
@@ -1,16 +1,26 @@
-use lrncore::path::change_work_dir;
-use crate::utils;
-use std::process::Command;
 use crate::projects::exit;
+use crate::utils;
+use lrncore::path::change_work_dir;
+use std::process::Command;
 
 use super::nxs;
 
-pub fn open_editor() {
+pub fn open_editor(project: &str) {
     change_work_dir(&utils::env::get_nyx_env_var());
-    let app_name = utils::prompt_message("Enter project name:".to_string(), "Failed to get user input".to_string());
+    let mut user_input_project = project.to_string();
+    if project.is_empty() {
+        let app_name = utils::prompt_message(
+            "Enter project name:".to_string(),
+            "Failed to get user input".to_string(),
+        );
+        user_input_project = app_name;
+    }
     let mut projects = nxs::get_all_project_entries();
     let location: String;
-    if let Some(pos) = projects.iter().position(|app| app.name == app_name) {
+    if let Some(pos) = projects
+        .iter()
+        .position(|app| app.name == user_input_project.as_str())
+    {
         let app = projects.remove(pos);
         location = app.location;
     } else {
@@ -19,9 +29,8 @@ pub fn open_editor() {
     }
 
     let editor_var = utils::env::get_editor_env_var();
-        Command::new(editor_var)
+    Command::new(editor_var)
         .arg(&location)
         .status()
         .expect("Something went wrong");
 }
-

--- a/src/utils/env.rs
+++ b/src/utils/env.rs
@@ -12,3 +12,11 @@ pub fn get_nyx_env_var() -> String {
         Err(e) => panic!("${} is not set ({})", env_var, e),
     }
 }
+
+pub fn get_editor_env_var() -> String {
+    let env_var = "EDITOR";
+    match env::var(env_var) {
+        Ok(e) => e,
+        Err(e) => panic!("${} is not set ({})", env_var, e),
+    }
+}


### PR DESCRIPTION
This pull request includes several changes to the `nyx` project, focusing on version updates and adding a new feature for opening an editor from the command line. The most important changes include updating the version number, introducing a new `open` subcommand, and adding utility functions to handle environment variables.

Version update:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3): Updated the package version from `1.10.3` to `1.12.0`.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL18-R18): Updated the `VERSION` constant to reflect the new version `1.12.0`.

New `open` subcommand:

* [`src/projects/mod.rs`](diffhunk://#diff-f8d3640f42becee8479e02f47a15638ab9c484aecf395a2d874b282e66b9293eR19-R28): Added the `open` subcommand to the project commands, allowing users to open their editor in the project location. [[1]](diffhunk://#diff-f8d3640f42becee8479e02f47a15638ab9c484aecf395a2d874b282e66b9293eR19-R28) [[2]](diffhunk://#diff-f8d3640f42becee8479e02f47a15638ab9c484aecf395a2d874b282e66b9293eR81-R90)
* [`src/projects/open/mod.rs`](diffhunk://#diff-32e0e0cc74c1c3e26b9a7b1315b34bb2200b4e1a5d3cba95f7cd63dbf28a0cecR1-R66): Implemented the `open_editor` function to handle opening the editor and added a help message for the `open` subcommand.

Utility functions:

* [`src/utils/env.rs`](diffhunk://#diff-e5d7ed8119b776ea1fa981d89411253893513918060556d5964634d0c90e6ac9R15-R22): Added the `get_editor_env_var` function to retrieve the `EDITOR` environment variable.