### PR TITLE
Improve modules directory

### DIFF
--- a/src/cleanup/mod.rs
+++ b/src/cleanup/mod.rs
@@ -1,6 +1,6 @@
 use std::{env, process::Command};
 
-use crate::{projects::nxs, utils};
+use crate::{nxfs::nxs, utils};
 use inquire::{InquireError, Select};
 use lrncore::usage_exit::command_usage;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod update;
 mod utils;
 use crate::projects::todo;
 use lrncore::usage_exit::command_usage;
-
+pub mod nxfs;
 use std::env;
 
 // Current version of NYX
@@ -91,9 +91,9 @@ fn main() {
     };
 
     match command {
-        Commands::Init => projects::nxs::create_data(),
-        Commands::CatNxs => projects::nxs::cat_nxs(),
-        Commands::CatNxp { hash } => projects::nxp::cat_nxp(hash),
+        Commands::Init => nxfs::nxs::create_data(),
+        Commands::CatNxs => nxfs::nxs::cat_nxs(),
+        Commands::CatNxp { hash } => nxfs::nxp::cat_nxp(hash),
         Commands::Project => projects::project_command(),
         Commands::Cleanup => cleanup::choose_cleanup(),
         Commands::Git => git::git_command(),

--- a/src/nxfs/mod.rs
+++ b/src/nxfs/mod.rs
@@ -1,0 +1,2 @@
+pub mod nxp;
+pub mod nxs;

--- a/src/nxfs/nxp.rs
+++ b/src/nxfs/nxp.rs
@@ -5,7 +5,6 @@ This module provides the definition of data structures and methods to create and
 It includes functionalities for reading, writing, and manipulating the binary data to ensure efficient storage and retrieval.
 */
 
-use crate::projects::Tabled;
 use crate::utils;
 use serde::Deserialize;
 use serde::Serialize;
@@ -15,6 +14,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::io::Read;
 use std::io::Write;
+use tabled::Tabled;
 
 use super::nxs;
 

--- a/src/nxfs/nxs.rs
+++ b/src/nxfs/nxs.rs
@@ -21,7 +21,7 @@ use std::process::Command;
 use super::nxp::parse_nxp_file;
 use super::nxp::NXPContentShort;
 use super::nxp::NXP;
-use crate::projects::nxp::{NXPContent, NXPHeader};
+use crate::nxfs::nxp::{NXPContent, NXPHeader};
 
 /*
 NXS file structure

--- a/src/projects/list/mod.rs
+++ b/src/projects/list/mod.rs
@@ -1,5 +1,5 @@
 use crate::gh;
-use crate::projects::nxs;
+use crate::nxfs::nxs;
 use crate::utils;
 use crate::vec_of_strings;
 use inquire::{error::InquireError, Select};

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -12,11 +12,11 @@ use tabled::Tabled;
 use todo::choose_todo;
 use update::update_project_properties;
 pub mod delete;
+use crate::nxfs;
 use lrncore::usage_exit::command_usage;
-pub mod nxp;
-pub mod nxs;
-pub mod todo;
+use nxfs::{nxp, nxs};
 pub mod open;
+pub mod todo;
 use open::open_editor;
 
 pub fn project_help() -> String {
@@ -86,8 +86,8 @@ pub fn project_command() {
             } else {
                 project_name = args[3].clone();
                 open_editor(&project_name);
-            } 
-        },        
+            }
+        }
         "add" => add_existing_project_to_list(),
         "list" => list_projects(),
         "delete" => select_remove_project(),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,7 +4,7 @@ This module provides various utility functions for the NYX project management to
 This module is intended to be used internally by the NYX project management tool to handle various utility tasks such as environment variable retrieval, file operations, user prompts, and more.
 */
 
-use crate::projects::nxp::NXPContent;
+use crate::nxfs::nxp::NXPContent;
 use std::env::var;
 use std::fs::write;
 use std::{


### PR DESCRIPTION
This pull request includes significant changes to the project structure by moving the `nxs` and `nxp` modules from the `projects` directory to a new `nxfs` directory. Additionally, it updates various file references to reflect this new structure.

### Project structure changes:

* [`src/cleanup/mod.rs`](diffhunk://#diff-471923b99804c8ba07d5908b3ac7c11480a703ca31625c58e39e95cf472aa0e5L3-R3): Updated import from `projects::nxs` to `nxfs::nxs`.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL12-R12): Added `nxfs` module and updated command match cases to use `nxfs::nxs` and `nxfs::nxp` instead of `projects::nxs` and `projects::nxp`. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL12-R12) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL94-R96)
* [`src/nxfs/mod.rs`](diffhunk://#diff-c6b5e87fe2950995eafd8b8ae0ce47c5e479bd0aa2282941870ad17914c8679bR1-R2): Added new module declarations for `nxp` and `nxs`.
* [`src/nxfs/nxp.rs`](diffhunk://#diff-5ab7530edbcc28f15ec082351155e34f3022118f0c4579ad4ef9474bde26593bL8): Renamed from `src/projects/nxp.rs` and updated import from `projects::Tabled` to `tabled::Tabled`. [[1]](diffhunk://#diff-5ab7530edbcc28f15ec082351155e34f3022118f0c4579ad4ef9474bde26593bL8) [[2]](diffhunk://#diff-5ab7530edbcc28f15ec082351155e34f3022118f0c4579ad4ef9474bde26593bR17)
* [`src/nxfs/nxs.rs`](diffhunk://#diff-dc788cf479b6cf2c5b618280498a21925726717f9461b125ce99f850eeea96c1L24-R24): Renamed from `src/projects/nxs.rs` and updated import to use `nxfs::nxp::{NXPContent, NXPHeader}`.

### File reference updates:

* [`src/projects/list/mod.rs`](diffhunk://#diff-e0b1eb902b29654a77b1ad7eb3ada10e2d843f5d1e3eef928fcba6fe62c72242L2-R2): Updated import from `projects::nxs` to `nxfs::nxs`.
* [`src/projects/mod.rs`](diffhunk://#diff-f8d3640f42becee8479e02f47a15638ab9c484aecf395a2d874b282e66b9293eR15-R19): Updated imports to use `nxfs::{nxp, nxs}` and removed old `nxp` and `nxs` module declarations.
* [`src/utils/mod.rs`](diffhunk://#diff-d3df0754141e5e2476f0425ab90722412a0348dec6263b76a9024970e822e816L7-R7): Updated import from `projects::nxp::NXPContent` to `nxfs::nxp::NXPContent`.