### PR TITLE
feat: add nxfs::config mod with basic command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +225,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +258,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -362,6 +384,7 @@ dependencies = [
  "sha1",
  "tabled",
  "throbber",
+ "toml",
 ]
 
 [[package]]
@@ -533,6 +556,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +666,40 @@ name = "throbber"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa679cdc0bc079431af2e764d22d46b261a21349b6fd9595749ba686d2170f05"
+
+[[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
 
 [[package]]
 name = "typenum"
@@ -910,3 +976,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ regex = "1.11.1"
 lrncore = { git = "https://github.com/Lrn-projects/LrnCore.git", version = "0.2.0", branch="main" }
 bincode = "1.0.0"
 sha1 = "0.10.6"
+toml = "0.8.20"

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,12 +26,13 @@ enum Commands {
     Git,
     Health,
     Update,
+    Config,
     Help,
     Version,
 }
 
 fn nyx_usage() -> &'static str {
-    let usage = r"
+    r"
 Usage: nyx command [options]
 
 A lightweight utility for efficient project management and useful tools.
@@ -45,15 +46,14 @@ Commands:
     git             Git command wrapped in a simplified interface
     health          Display current development system health
     update          Update the current version of NYX
+    config          Manage nyx configuration
     help            Show this help message
 
 Options:
 
     -h, --help      Show command usage
     -v, --version   Show the current version of NYX
-";
-
-    return usage;
+"
 }
 
 fn main() {
@@ -81,6 +81,7 @@ fn main() {
         Some("cleanup") => Commands::Cleanup,
         Some("git") => Commands::Git,
         Some("health") => Commands::Health,
+        Some("config") => Commands::Config,
         Some("update") => Commands::Update,
         Some("help") => Commands::Help,
         Some("version") => Commands::Version,
@@ -98,6 +99,7 @@ fn main() {
         Commands::Cleanup => cleanup::choose_cleanup(),
         Commands::Git => git::git_command(),
         Commands::Health => health::dev_env_health(),
+        Commands::Config => nxfs::config::config_command(),
         Commands::Update => update::update_bin(),
         Commands::Help => command_usage(nyx_usage()),
         Commands::Version => command_usage(&nyx_version()),

--- a/src/nxfs/config.rs
+++ b/src/nxfs/config.rs
@@ -5,7 +5,8 @@ use lrncore::usage_exit::command_usage;
 use std::env;
 use crate::utils;
 use std::fmt::Debug;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use std::fs::OpenOptions;
 
 fn config_help() -> String {
     let usage = r"
@@ -21,21 +22,56 @@ Options:
         ";
     usage.to_string()
 }
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct Config {
     config: ConfigHeader,
-    git: ConfigGit
+    user: ConfigUser,
+    git: ConfigGit,
+    behavior: ConfigBehavior,
+    ui: ConfigUi,
+    internal_path: ConfigInternPath,
+    security: ConfigSecure,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct ConfigHeader {
     format: String,
     version: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
+struct ConfigUser {
+    name: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 struct ConfigGit {
     profile_url: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ConfigBehavior {
+    default_editor: String,
+    auto_update: bool,
+    ask_confirmation: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ConfigUi {
+
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ConfigInternPath {
+    data: String,
+    logs: String,
+    cache: String,
+
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ConfigSecure {
+    secure_mode: bool,
 }
 
 fn config_template() -> String {
@@ -43,10 +79,27 @@ fn config_template() -> String {
 format = 'nxs_config'
 version = '0.1.0'
 
+[user]
+name = ''
+
 [git]
 profile_url = ''
 
-        ";
+[behavior]
+default_editor = 'vim'
+auto_update = false
+ask_confirmation = true
+
+[ui]
+
+[internal_path]
+data = ''
+logs = ''
+cache = ''
+
+[security]
+secure_mode = false
+    ";
     template.to_string()
 }
 
@@ -90,14 +143,41 @@ fn init_config() {
 
 fn parse_config_file() {
     let config_path = ".nxfs/config.toml".to_string();
-    let file = std::fs::read_to_string(config_path).expect("Failed to read the config file to string");
-    let config_config: Config = match toml::from_str(&file) {
+    let file = std::fs::read_to_string(&config_path).expect("Failed to read the config file to string");
+    let mut config: Config = match toml::from_str(&file) {
         Ok(c) => c,            
         Err(e) => {
             lrncore::logs::error_log(&format!("Failed to write the config file: {}", e));
             exit(1);      
         }
     };
-
-    println!("debug {:?}", config_config);
+    let ask_username = utils::prompt_message("Enter a username:".to_string(), "Failed to get user input".to_string());
+    let ask_github_profile = utils::prompt_message("Enter your github profile url:".to_string(), "Failed to get user input".to_string());
+    let data_dir = format!("{}/.nxfs/", utils::env::get_nyx_env_var());
+    let log_dir = data_dir.clone() + "logs/";
+    let cache_dir = data_dir.clone() + "cache/";
+    config.user.name = ask_username;
+    config.git.profile_url = ask_github_profile;
+    config.internal_path.data = data_dir;
+    config.internal_path.logs = log_dir;
+    config.internal_path.cache = cache_dir;
+    let mut nxs_file: File = match OpenOptions::new()
+        .write(true)
+        .create(false)
+        .truncate(true)
+        .open(config_path)
+        {
+            Ok(f) => f,
+            Err(e) => {
+                lrncore::logs::error_log(&format!("Failed to open config file: {}", e));
+                return;
+            }
+        };
+    let buf = bincode::serialize(&config).expect("Failed to serialize new config file");
+    match nxs_file.write_all(&buf) {
+        Ok(_) => (),
+        Err(e) => {
+            lrncore::logs::error_log(&format!("Failed to write buffer in config file: {}", e));
+        }
+    };
 }

--- a/src/nxfs/config.rs
+++ b/src/nxfs/config.rs
@@ -1,12 +1,15 @@
-use std::{fs::File, io::Write, process::exit};
+use std::{
+    fs::File,
+    io::Write,
+    process::exit,
+};
 
+use crate::utils;
 use lrncore::path::change_work_dir;
 use lrncore::usage_exit::command_usage;
-use std::env;
-use crate::utils;
-use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
-use std::fs::OpenOptions;
+use std::env;
+use std::fmt::Debug;
 
 fn config_help() -> String {
     let usage = r"
@@ -57,16 +60,13 @@ struct ConfigBehavior {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-struct ConfigUi {
-
-}
+struct ConfigUi {}
 
 #[derive(Debug, Deserialize, Serialize)]
 struct ConfigInternPath {
     data: String,
     logs: String,
     cache: String,
-
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -122,37 +122,28 @@ pub fn config_command() {
 fn init_config() {
     let config_path = ".nxfs/config.toml".to_string();
     let mut config_file = match File::create_new(config_path) {
-        Ok(f)=> f,
+        Ok(f) => f,
         Err(e) => {
             lrncore::logs::error_log(&format!("Failed to initialize config file: {}", e));
-            return;      
+            return;
         }
     };
     let template = config_template();
-    let buf = template.as_bytes();
-    match config_file.write_all(buf) {
-        Ok(_) => (),
+    let mut config: Config = match toml::from_str(&template) {
+        Ok(c) => c,
         Err(e) => {
-            lrncore::logs::error_log(&format!("Failed to write the config file: {}", e));
-            exit(1);      
+            lrncore::logs::error_log(&format!("Failed to deserialize config template: {}", e));
+            return;
         }
     };
-    lrncore::logs::info_log("Successfully initialized nyx config file!");
-    parse_config_file();
-}
-
-fn parse_config_file() {
-    let config_path = ".nxfs/config.toml".to_string();
-    let file = std::fs::read_to_string(&config_path).expect("Failed to read the config file to string");
-    let mut config: Config = match toml::from_str(&file) {
-        Ok(c) => c,            
-        Err(e) => {
-            lrncore::logs::error_log(&format!("Failed to write the config file: {}", e));
-            exit(1);      
-        }
-    };
-    let ask_username = utils::prompt_message("Enter a username:".to_string(), "Failed to get user input".to_string());
-    let ask_github_profile = utils::prompt_message("Enter your github profile url:".to_string(), "Failed to get user input".to_string());
+    let ask_username = utils::prompt_message(
+        "Enter a username:".to_string(),
+        "Failed to get user input".to_string(),
+    );
+    let ask_github_profile = utils::prompt_message(
+        "Enter your github profile url:".to_string(),
+        "Failed to get user input".to_string(),
+    );
     let data_dir = format!("{}/.nxfs/", utils::env::get_nyx_env_var());
     let log_dir = data_dir.clone() + "logs/";
     let cache_dir = data_dir.clone() + "cache/";
@@ -161,23 +152,29 @@ fn parse_config_file() {
     config.internal_path.data = data_dir;
     config.internal_path.logs = log_dir;
     config.internal_path.cache = cache_dir;
-    let mut nxs_file: File = match OpenOptions::new()
-        .write(true)
-        .create(false)
-        .truncate(true)
-        .open(config_path)
-        {
-            Ok(f) => f,
-            Err(e) => {
-                lrncore::logs::error_log(&format!("Failed to open config file: {}", e));
-                return;
-            }
-        };
-    let buf = bincode::serialize(&config).expect("Failed to serialize new config file");
-    match nxs_file.write_all(&buf) {
+
+    let config_str = toml::to_string(&config).expect("Failed to parse config struct to string");
+    let buf = config_str.as_bytes();
+    match config_file.write_all(buf) {
         Ok(_) => (),
         Err(e) => {
-            lrncore::logs::error_log(&format!("Failed to write buffer in config file: {}", e));
+            lrncore::logs::error_log(&format!("Failed to write the config file: {}", e));
+            exit(1);
         }
     };
+    lrncore::logs::info_log("Successfully initialized nyx config file!");
+}
+
+fn parse_config_file() -> Config {
+    let config_path = ".nxfs/config.toml".to_string();
+    let file =
+        std::fs::read_to_string(&config_path).expect("Failed to read the config file to string");
+    let config: Config = match toml::from_str(&file) {
+        Ok(c) => c,
+        Err(e) => {
+            lrncore::logs::error_log(&format!("Failed to write the config file: {}", e));
+            exit(1);
+        }
+    };
+    config
 }

--- a/src/nxfs/config.rs
+++ b/src/nxfs/config.rs
@@ -1,0 +1,71 @@
+use std::{fs::File, io::Write, process::exit};
+
+use lrncore::path::change_work_dir;
+use lrncore::usage_exit::command_usage;
+use std::env;
+use crate::utils;
+
+fn config_help() -> String {
+    let usage = r"
+Usage: nyx config [subcommand] [arguments] [options]
+
+Subcommands:
+    init         Initialize the config file
+
+
+Options:
+    -h, --help      Show this help message
+
+        ";
+    usage.to_string()
+}
+
+fn config_template() -> String {
+    let template = r"
+[config]
+type = 'nxs_config'
+version = '0.1.0'
+
+[git]
+profile_url = ''
+
+        ";
+    template.to_string()
+}
+
+pub fn config_command() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() <= 2 {
+        command_usage(&config_help());
+    }
+    match args[2].as_str() {
+        "init" => init_config(),
+        
+        _ => {
+            lrncore::logs::warning_log("Unknown command");
+            command_usage(&config_help());
+        }
+    }
+}
+
+fn init_config() {
+    change_work_dir(&utils::env::get_nyx_env_var());
+    let config_path = ".nxfs/config.toml".to_string();
+    let mut config_file = match File::create_new(config_path) {
+        Ok(f)=> f,
+        Err(e) => {
+            lrncore::logs::error_log(&format!("Failed to initialize config file: {}", e));
+            return;      
+        }
+    };
+    let template = config_template();
+    let buf = template.as_bytes();
+    match config_file.write_all(buf) {
+        Ok(_) => (),
+        Err(e) => {
+            lrncore::logs::error_log(&format!("Failed to write the config file: {}", e));
+            exit(1);      
+        }
+    };
+    lrncore::logs::info_log("Successfully initialized nyx config file!");
+}

--- a/src/nxfs/config.rs
+++ b/src/nxfs/config.rs
@@ -4,6 +4,8 @@ use lrncore::path::change_work_dir;
 use lrncore::usage_exit::command_usage;
 use std::env;
 use crate::utils;
+use std::fmt::Debug;
+use serde::Deserialize;
 
 fn config_help() -> String {
     let usage = r"
@@ -19,11 +21,26 @@ Options:
         ";
     usage.to_string()
 }
+#[derive(Debug, Deserialize)]
+struct Config {
+    config: ConfigHeader,
+    git: ConfigGit
+}
+
+#[derive(Debug, Deserialize)]
+struct ConfigHeader {
+    format: String,
+    version: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ConfigGit {
+    profile_url: String,
+}
 
 fn config_template() -> String {
-    let template = r"
-[config]
-type = 'nxs_config'
+    let template = r"[config]
+format = 'nxs_config'
 version = '0.1.0'
 
 [git]
@@ -34,6 +51,7 @@ profile_url = ''
 }
 
 pub fn config_command() {
+    change_work_dir(&utils::env::get_nyx_env_var());
     let args: Vec<String> = env::args().collect();
     if args.len() <= 2 {
         command_usage(&config_help());
@@ -49,7 +67,6 @@ pub fn config_command() {
 }
 
 fn init_config() {
-    change_work_dir(&utils::env::get_nyx_env_var());
     let config_path = ".nxfs/config.toml".to_string();
     let mut config_file = match File::create_new(config_path) {
         Ok(f)=> f,
@@ -68,4 +85,19 @@ fn init_config() {
         }
     };
     lrncore::logs::info_log("Successfully initialized nyx config file!");
+    parse_config_file();
+}
+
+fn parse_config_file() {
+    let config_path = ".nxfs/config.toml".to_string();
+    let file = std::fs::read_to_string(config_path).expect("Failed to read the config file to string");
+    let config_config: Config = match toml::from_str(&file) {
+        Ok(c) => c,            
+        Err(e) => {
+            lrncore::logs::error_log(&format!("Failed to write the config file: {}", e));
+            exit(1);      
+        }
+    };
+
+    println!("debug {:?}", config_config);
 }

--- a/src/nxfs/config.rs
+++ b/src/nxfs/config.rs
@@ -23,52 +23,52 @@ Options:
     usage.to_string()
 }
 #[derive(Debug, Deserialize, Serialize)]
-struct Config {
-    config: ConfigHeader,
-    user: ConfigUser,
-    git: ConfigGit,
-    behavior: ConfigBehavior,
-    ui: ConfigUi,
-    internal_path: ConfigInternPath,
-    security: ConfigSecure,
+pub struct Config {
+    pub config: ConfigHeader,
+    pub user: ConfigUser,
+    pub git: ConfigGit,
+    pub behavior: ConfigBehavior,
+    pub ui: ConfigUi,
+    pub internal_path: ConfigInternPath,
+    pub security: ConfigSecure,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-struct ConfigHeader {
-    format: String,
-    version: String,
+pub struct ConfigHeader {
+    pub format: String,
+    pub version: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-struct ConfigUser {
-    name: String,
+pub struct ConfigUser {
+    pub name: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-struct ConfigGit {
-    profile_url: String,
+pub struct ConfigGit {
+    pub profile_url: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-struct ConfigBehavior {
-    default_editor: String,
-    auto_update: bool,
-    ask_confirmation: bool,
+pub struct ConfigBehavior {
+    pub default_editor: String,
+    pub auto_update: bool,
+    pub ask_confirmation: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-struct ConfigUi {}
+pub struct ConfigUi {}
 
 #[derive(Debug, Deserialize, Serialize)]
-struct ConfigInternPath {
-    data: String,
-    logs: String,
-    cache: String,
+pub struct ConfigInternPath {
+    pub data: String,
+    pub logs: String,
+    pub cache: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-struct ConfigSecure {
-    secure_mode: bool,
+pub struct ConfigSecure {
+    pub secure_mode: bool,
 }
 
 fn config_template() -> String {
@@ -162,7 +162,7 @@ fn init_config() {
     lrncore::logs::info_log("Successfully initialized nyx config file!");
 }
 
-fn parse_config_file() -> Result<Config, toml_error> {
+pub fn parse_config_file() -> Result<Config, toml_error> {
     let config_path = ".nxfs/config.toml".to_string();
     let file =
         std::fs::read_to_string(&config_path).expect("Failed to read the config file to string");

--- a/src/nxfs/config.rs
+++ b/src/nxfs/config.rs
@@ -1,8 +1,4 @@
-use std::{
-    fs::File,
-    io::Write,
-    process::exit,
-};
+use std::{fs::File, io::Write, process::exit};
 
 use crate::utils;
 use lrncore::path::change_work_dir;
@@ -10,6 +6,7 @@ use lrncore::usage_exit::command_usage;
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::fmt::Debug;
+use toml::de::Error as toml_error;
 
 fn config_help() -> String {
     let usage = r"
@@ -111,7 +108,7 @@ pub fn config_command() {
     }
     match args[2].as_str() {
         "init" => init_config(),
-        
+
         _ => {
             lrncore::logs::warning_log("Unknown command");
             command_usage(&config_help());
@@ -165,7 +162,7 @@ fn init_config() {
     lrncore::logs::info_log("Successfully initialized nyx config file!");
 }
 
-fn parse_config_file() -> Config {
+fn parse_config_file() -> Result<Config, toml_error> {
     let config_path = ".nxfs/config.toml".to_string();
     let file =
         std::fs::read_to_string(&config_path).expect("Failed to read the config file to string");
@@ -173,8 +170,8 @@ fn parse_config_file() -> Config {
         Ok(c) => c,
         Err(e) => {
             lrncore::logs::error_log(&format!("Failed to write the config file: {}", e));
-            exit(1);
+            return Err(e);
         }
     };
-    config
+    Ok(config)
 }

--- a/src/nxfs/mod.rs
+++ b/src/nxfs/mod.rs
@@ -1,2 +1,3 @@
 pub mod nxp;
 pub mod nxs;
+pub mod config;

--- a/src/nxfs/nxs.rs
+++ b/src/nxfs/nxs.rs
@@ -114,6 +114,8 @@ pub fn create_data() {
         .arg(".nxfs")
         .arg(".nxfs/projects")
         .arg(".nxfs/tmp")
+        .arg(".nxfs/logs")
+        .arg(".nxfs/cache")
         .spawn()
         .expect("Failed to create all directories");
     let wait_mkdir = mkdir.wait().expect("Failed to wait mkdir command");

--- a/src/projects/open/mod.rs
+++ b/src/projects/open/mod.rs
@@ -1,5 +1,5 @@
 use crate::projects::exit;
-use crate::utils;
+use crate::{nxfs, utils};
 use lrncore::path::change_work_dir;
 use std::process::Command;
 use lrncore::usage_exit::command_usage;
@@ -21,7 +21,6 @@ Options:
 
     usage.to_string()
 }
-
 
 pub fn open_editor(project: &str) {
     change_work_dir(&utils::env::get_nyx_env_var());
@@ -58,7 +57,8 @@ pub fn open_editor(project: &str) {
         exit(1);
     }
 
-    let editor_var = utils::env::get_editor_env_var();
+    let config = nxfs::config::parse_config_file().expect("Failed to parse nyx config file");
+    let editor_var = config.behavior.default_editor;
     Command::new(editor_var)
         .arg(&location)
         .status()

--- a/src/utils/editor.rs
+++ b/src/utils/editor.rs
@@ -6,7 +6,6 @@ use crate::utils::File;
 use crate::utils::NXPContent;
 use lrncore::path::change_work_dir;
 use std::io::Read;
-use toml::de::Error;
 
 /// The `update_editor` function updates a file using the specified editor and prints its
 /// content.
@@ -23,10 +22,6 @@ pub fn update_editor(content: NXPContent) -> Vec<u8> {
         Ok(c) => {
             editor = c.behavior.default_editor
         },
-        Ok(_) => {
-            lrncore::logs::warning_log("EDITOR var not defined in config file.");
-            editor = "vim".to_string();
-        }
         Err(e) => {
             lrncore::logs::warning_log(&format!("Failed to parse config file: {}", e));
             return vec![];
@@ -58,7 +53,7 @@ pub fn update_editor(content: NXPContent) -> Vec<u8> {
         }
     }
     Command::new(editor)
-        .arg(&file_path)
+        .arg(file_path)
         .status()
         .expect("Something went wrong");
 
@@ -82,5 +77,5 @@ pub fn update_editor(content: NXPContent) -> Vec<u8> {
     };
     let buffer: Vec<u8> =
         bincode::serialize(&update_content).expect("Failed to serialize updated content struct");
-    return buffer;
+    buffer
 }

--- a/src/utils/editor.rs
+++ b/src/utils/editor.rs
@@ -1,11 +1,12 @@
+use crate::nxfs;
 use crate::utils::env::get_nyx_env_var;
-use crate::utils::var;
 use crate::utils::write;
 use crate::utils::Command;
 use crate::utils::File;
 use crate::utils::NXPContent;
 use lrncore::path::change_work_dir;
 use std::io::Read;
+use toml::de::Error;
 
 /// The `update_editor` function updates a file using the specified editor and prints its
 /// content.
@@ -17,15 +18,22 @@ use std::io::Read;
 /// user's preferred text editor for editing.
 pub fn update_editor(content: NXPContent) -> Vec<u8> {
     change_work_dir(&get_nyx_env_var());
-    let editor = match var("EDITOR") {
-        Ok(str) => str,
+    let editor: String;
+    match nxfs::config::parse_config_file() {
+        Ok(c) => {
+            editor = c.behavior.default_editor
+        },
+        Ok(_) => {
+            lrncore::logs::warning_log("EDITOR var not defined in config file.");
+            editor = "vim".to_string();
+        }
         Err(e) => {
-            lrncore::logs::warning_log(&format!("EDITOR var not defined: {}", e));
-            "vim".to_string()
+            lrncore::logs::warning_log(&format!("Failed to parse config file: {}", e));
+            return vec![];
         }
     };
     let file_path = ".nxfs/tmp/PROJECT_EDIT";
-    match File::create(&file_path) {
+    match File::create(file_path) {
         Ok(f) => f,
         Err(e) => {
             lrncore::logs::error_log(&format!("Failed to temp file: {}", e));

--- a/src/utils/env.rs
+++ b/src/utils/env.rs
@@ -13,10 +13,3 @@ pub fn get_nyx_env_var() -> String {
     }
 }
 
-pub fn get_editor_env_var() -> String {
-    let env_var = "EDITOR";
-    match env::var(env_var) {
-        Ok(e) => e,
-        Err(e) => panic!("${} is not set ({})", env_var, e),
-    }
-}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,7 +5,6 @@ This module is intended to be used internally by the NYX project management tool
 */
 
 use crate::nxfs::nxp::NXPContent;
-use std::env::var;
 use std::fs::write;
 use std::{
     fs::File,
@@ -54,7 +53,7 @@ pub fn get_tech_option() -> Vec<String> {
         "C++".to_string(),
         "Other".to_string(),
     ];
-    return options;
+    options
 }
 
 pub fn get_select_project_option(prompt: String) -> std::result::Result<String, InquireError> {
@@ -62,7 +61,7 @@ pub fn get_select_project_option(prompt: String) -> std::result::Result<String, 
 
     let ans: std::result::Result<String, InquireError> = Select::new(&prompt, options).prompt();
 
-    return ans;
+    ans
 }
 
 pub fn get_select_option(
@@ -71,7 +70,7 @@ pub fn get_select_option(
 ) -> std::result::Result<String, InquireError> {
     let ans: std::result::Result<String, InquireError> = Select::new(&prompt, option).prompt();
 
-    return ans;
+    ans
 }
 
 pub fn prompt_message(message: String, error_message: String) -> String {
@@ -93,7 +92,7 @@ pub fn nyx_ascii_art() -> String {
 
 ";
 
-    return ascii_art.to_string();
+    ascii_art.to_string()
 }
 
 pub fn custom_throbber(message: String) -> Throbber {


### PR DESCRIPTION
This pull request introduces a new configuration management feature to the `nyx` project and includes several related changes across multiple files. The most important changes include adding a new `Config` command, implementing configuration file parsing and initialization, and updating various parts of the codebase to use the new configuration settings.

### Configuration Management:

* Added a new `Config` command to the `Commands` enum in `src/main.rs` and updated the command usage information accordingly. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR29-R35) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR49-R56) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR84) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR102)

* Implemented configuration management in a new file `src/nxfs/config.rs`, which includes functions to initialize and parse the configuration file.

### Codebase Updates:

* Updated `Cargo.toml` to include the `toml` crate for handling TOML files.

* Modified `src/nxfs/mod.rs` to include the new `config` module.

* Updated `src/nxfs/nxs.rs` to create additional directories for logs and cache.

* Refactored `src/projects/open/mod.rs` and `src/utils/editor.rs` to use the new configuration settings for the default editor. [[1]](diffhunk://#diff-32e0e0cc74c1c3e26b9a7b1315b34bb2200b4e1a5d3cba95f7cd63dbf28a0cecL2-R2) [[2]](diffhunk://#diff-32e0e0cc74c1c3e26b9a7b1315b34bb2200b4e1a5d3cba95f7cd63dbf28a0cecL25) [[3]](diffhunk://#diff-32e0e0cc74c1c3e26b9a7b1315b34bb2200b4e1a5d3cba95f7cd63dbf28a0cecL61-R61) [[4]](diffhunk://#diff-fa36e75d8dc870cb21a5cb076beeff1a64fa35158f0172806033ed3ce7a9b9bdR1-L2) [[5]](diffhunk://#diff-fa36e75d8dc870cb21a5cb076beeff1a64fa35158f0172806033ed3ce7a9b9bdL20-R31) [[6]](diffhunk://#diff-fa36e75d8dc870cb21a5cb076beeff1a64fa35158f0172806033ed3ce7a9b9bdL53-R56) [[7]](diffhunk://#diff-fa36e75d8dc870cb21a5cb076beeff1a64fa35158f0172806033ed3ce7a9b9bdL77-R80)

* Removed the `get_editor_env_var` function from `src/utils/env.rs` and updated related code to use the configuration settings instead. [[1]](diffhunk://#diff-e5d7ed8119b776ea1fa981d89411253893513918060556d5964634d0c90e6ac9L16-L22) [[2]](diffhunk://#diff-d3df0754141e5e2476f0425ab90722412a0348dec6263b76a9024970e822e816L8) [[3]](diffhunk://#diff-d3df0754141e5e2476f0425ab90722412a0348dec6263b76a9024970e822e816L57-R64) [[4]](diffhunk://#diff-d3df0754141e5e2476f0425ab90722412a0348dec6263b76a9024970e822e816L74-R73) [[5]](diffhunk://#diff-d3df0754141e5e2476f0425ab90722412a0348dec6263b76a9024970e822e816L96-R95)