### PR TITLE
103 fix project open command

### DIFF
--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -165,11 +165,15 @@ fn new_nodejs_project(tech: &str) {
     if !ts_status.success() {
         panic!("Error installing typescript");
     }
-    Command::new("touch")
+    let mut touch = Command::new("touch")
         .arg("tsconfig.json")
         .spawn()
         .expect("failed to generate tsconfig.json");
-    templates::new_gitignore(&tech);
+    let wait_touch = touch.wait().expect("Failed to wait touch command");
+    if !wait_touch.success() {
+        panic!("Error in the execution of touch command");
+    }
+    templates::new_gitignore(tech);
     println!("Successfully generate the new Node.js project")
 }
 
@@ -186,7 +190,7 @@ fn new_python_project(tech: &str) {
     if !venv_status.success() {
         panic!("Error init python virtual environment")
     }
-    templates::new_gitignore(&tech);
+    templates::new_gitignore(tech);
     println!("Successfully generate the new Python project");
 }
 
@@ -203,7 +207,7 @@ fn new_golang_project(name: &str, tech: &str) {
     if !go_status.success() {
         panic!("Error init the Golang project");
     }
-    templates::new_gitignore(&tech);
+    templates::new_gitignore(tech);
 }
 
 fn new_rust_project(tech: &str) {
@@ -217,5 +221,5 @@ fn new_rust_project(tech: &str) {
     if !cargo_status.success() {
         panic!("Error init the Rust project")
     }
-    templates::new_gitignore(&tech);
+    templates::new_gitignore(tech);
 }

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -34,7 +34,7 @@ Subcommands:
 
 Options:
     -h, --help      Show this help message
-";
+    ";
 
     usage.to_string()
 }

--- a/src/projects/open/mod.rs
+++ b/src/projects/open/mod.rs
@@ -56,11 +56,10 @@ pub fn open_editor(project: &str) {
         lrncore::logs::error_log("Project not found");
         exit(1);
     }
-
     let config = nxfs::config::parse_config_file().expect("Failed to parse nyx config file");
     let editor_var = config.behavior.default_editor;
+    change_work_dir(&location);
     Command::new(editor_var)
-        .arg(&location)
         .status()
         .expect("Something went wrong");
 }


### PR DESCRIPTION
This pull request includes several changes to improve error handling and code consistency in the `src/projects/mod.rs` file, as well as a minor adjustment in the `src/projects/open/mod.rs` file.

### Error Handling Improvements:
* [`src/projects/mod.rs`](diffhunk://#diff-f8d3640f42becee8479e02f47a15638ab9c484aecf395a2d874b282e66b9293eL168-R176): Added error handling for the `touch` command in the `new_nodejs_project` function to ensure the command executes successfully before proceeding.

### Code Consistency:
* Updated the `new_gitignore` function calls in `new_nodejs_project`, `new_python_project`, `new_golang_project`, and `new_rust_project` functions to pass the `tech` parameter without borrowing it. [[1]](diffhunk://#diff-f8d3640f42becee8479e02f47a15638ab9c484aecf395a2d874b282e66b9293eL189-R193) [[2]](diffhunk://#diff-f8d3640f42becee8479e02f47a15638ab9c484aecf395a2d874b282e66b9293eL206-R210) [[3]](diffhunk://#diff-f8d3640f42becee8479e02f47a15638ab9c484aecf395a2d874b282e66b9293eL220-R224)

### Minor Adjustments:
* [`src/projects/open/mod.rs`](diffhunk://#diff-32e0e0cc74c1c3e26b9a7b1315b34bb2200b4e1a5d3cba95f7cd63dbf28a0cecL59-L63): Removed an unnecessary blank line and reordered the `change_work_dir` function call to occur before opening the editor.