### PR TITLE
113 add validation when init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "nyx"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyx"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2021"
 authors = ["Elouan DA COSTA PEIXOTO <elouandacostapeixoto@gmail.com>"]
 description = "A CLI tool for managing your projects."

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod hello;
 // Current version of NYX
 // if modified and then running update command it will replace
 // your current nyx installation with the newer version
-const VERSION: &str = "2.3.0";
+const VERSION: &str = "2.3.1";
 #[derive(Debug, Clone)]
 enum Commands {
     Init,

--- a/src/nxfs/nxs.rs
+++ b/src/nxfs/nxs.rs
@@ -104,6 +104,10 @@ pub struct ProjectEntry {
 pub fn create_data() {
     lrncore::path::change_work_dir(&utils::env::get_nyx_env_var());
     if Path::new(".nxfs").exists() {
+        let confirm = utils::prompt::confirm_prompt("Are you sure you want to Reinitialize NYX ?", "It will remove all projects saved in nxfs storage");
+        if !confirm {
+            return;
+        }
         lrncore::logs::info_log("Reinitialized data folder");
         let remove_dir = fs::remove_dir_all(".nxfs");
         if let Err(e) = remove_dir {

--- a/src/projects/todo/mod.rs
+++ b/src/projects/todo/mod.rs
@@ -227,7 +227,7 @@ fn prune_todo() {
     }
     let project_hash_str = String::from_utf8_lossy(&project_hash);
 
-    let confirm = utils::confirm_prompt(
+    let confirm = utils::prompt::confirm_prompt(
         "Are you sure to clear the list ?",
         "It will remove completely the todo file from your system.",
     );

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -13,12 +13,13 @@ use std::{
 
 use inquire::{
     ui::{Attributes, Color, RenderConfig, StyleSheet, Styled},
-    Confirm, InquireError, Select, Text,
+    InquireError, Select, Text,
 };
 use throbber::Throbber;
 pub mod editor;
 pub mod env;
 pub mod fsys;
+pub mod prompt;
 
 pub fn get_render_config() -> RenderConfig<'static> {
     let mut render_config = RenderConfig::default();
@@ -98,12 +99,4 @@ pub fn nyx_ascii_art() -> String {
 pub fn custom_throbber(message: String) -> Throbber {
     let custom_throbber = Throbber::new().message(message).frames(&throbber::ROTATE_F);
     return custom_throbber;
-}
-
-pub fn confirm_prompt(message: &str, help_message: &str) -> bool {
-    let ans = Confirm::new(message)
-        .with_default(false)
-        .with_help_message(help_message)
-        .prompt();
-    ans.unwrap()
 }

--- a/src/utils/prompt.rs
+++ b/src/utils/prompt.rs
@@ -1,0 +1,16 @@
+use inquire::Confirm;
+
+use crate::nxfs;
+
+/// confirmation prompt for the user if ask_confirmation is enabled in config file
+pub fn confirm_prompt(message: &str, help_message: &str) -> bool {
+    let config = nxfs::config::parse_config_file().expect("Failed to parse NYX config file");
+    if config.behavior.ask_confirmation {
+        return Confirm::new(message)
+            .with_default(false)
+            .with_help_message(help_message)
+            .prompt()
+            .unwrap();
+    }
+    true
+}


### PR DESCRIPTION
This pull request introduces several updates to the `nyx` project, including a version bump, enhancements to user prompts, and codebase restructuring to improve modularity. The most significant changes involve introducing a new `prompt` module, updating the confirmation prompt logic, and adding a safeguard for reinitializing data. Below is a breakdown of the key changes:

### Version Update:
* Updated the project version from `2.3.0` to `2.3.1` in `Cargo.toml` and `src/main.rs` to reflect the new release. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL19-R19)

### Enhancements to User Prompts:
* Added a confirmation prompt when reinitializing the `.nxfs` data folder to warn users about the potential loss of saved projects.
* Refactored the `confirm_prompt` function to include behavior based on a configuration file (`ask_confirmation` setting). This function now resides in a new `prompt` module for better modularity. [[1]](diffhunk://#diff-d3df0754141e5e2476f0425ab90722412a0348dec6263b76a9024970e822e816L102-L109) [[2]](diffhunk://#diff-f12cdbc53b7aa685172a58f497cc2bacf871772ca2dd3d6221ec36073506446cR1-R16)

### Codebase Restructuring:
* Removed the `confirm_prompt` function from `src/utils/mod.rs` and moved it to the newly created `src/utils/prompt.rs` module. This improves code organization by grouping prompt-related logic in one place. [[1]](diffhunk://#diff-d3df0754141e5e2476f0425ab90722412a0348dec6263b76a9024970e822e816L102-L109) [[2]](diffhunk://#diff-f12cdbc53b7aa685172a58f497cc2bacf871772ca2dd3d6221ec36073506446cR1-R16)
* Updated all references to `confirm_prompt` to use the new `utils::prompt::confirm_prompt` path.

### Dependency Cleanup:
* Removed the unused `Confirm` import from `src/utils/mod.rs` after moving the `confirm_prompt` function to the `prompt` module.