### PR TITLE
119 add more config command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "nyx"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyx"
-version = "2.4.0"
+version = "2.5.0"
 edition = "2021"
 authors = ["Elouan DA COSTA PEIXOTO <elouandacostapeixoto@gmail.com>"]
 description = "A CLI tool for managing your projects."

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod hello;
 // Current version of NYX
 // if modified and then running update command it will replace
 // your current nyx installation with the newer version
-const VERSION: &str = "2.4.0";
+const VERSION: &str = "2.5.0";
 #[derive(Debug, Clone)]
 enum Commands {
     Init,

--- a/src/nxfs/config.rs
+++ b/src/nxfs/config.rs
@@ -223,10 +223,10 @@ fn update_config() {
 fn cat_config() {
     change_work_dir(&utils::env::get_nyx_env_var());
     let config_path = ".nxfs/config.toml";
-    if !fs::exists(config_path).expect("Failed to check if the configuration path exist") {
+    if !fs::exists(config_path).expect("Failed to check if the configuration path exists") {
         log_from_log_level(
             LogLevel::Error,
-            "Config file path doesn't exit. Check if the configuration file exist",
+            "Config file path doesn't exist. Check if the configuration file exists",
         );
         exit(1);
     }

--- a/src/nxfs/config.rs
+++ b/src/nxfs/config.rs
@@ -1,3 +1,4 @@
+use std::process::{Command, Stdio};
 use std::{fs::File, io::Write, process::exit};
 
 use crate::utils;
@@ -6,8 +7,8 @@ use crate::utils::log::log_from_log_level;
 use lrncore::path::change_work_dir;
 use lrncore::usage_exit::command_usage;
 use serde::{Deserialize, Serialize};
-use std::{env, fs};
 use std::fmt::Debug;
+use std::{env, fs};
 use toml::de::Error as toml_error;
 
 fn config_help() -> String {
@@ -124,6 +125,7 @@ pub fn config_command() {
     match args[2].as_str() {
         "init" => init_config(),
         "update" => update_config(),
+        "cat" => cat_config(),
 
         _ => {
             command_usage(&config_help());
@@ -194,7 +196,10 @@ pub fn parse_config_file() -> Result<Config, toml_error> {
     let config: Config = match toml::from_str(&file) {
         Ok(c) => c,
         Err(e) => {
-            log_from_log_level(LogLevel::Error, &format!("Failed to parse the config file: {}", e));
+            log_from_log_level(
+                LogLevel::Error,
+                &format!("Failed to parse the config file: {}", e),
+            );
             return Err(e);
         }
     };
@@ -205,8 +210,29 @@ fn update_config() {
     change_work_dir(&utils::env::get_nyx_env_var());
     let config_path = ".nxfs/config.toml";
     if !fs::exists(config_path).expect("Failed to check if the configuration path exist") {
-        log_from_log_level(LogLevel::Error, "Config file path doesn't exit. Check if the configuration file exist");
+        log_from_log_level(
+            LogLevel::Error,
+            "Config file path doesn't exit. Check if the configuration file exist",
+        );
     }
     open_new_editor(config_path);
     log_from_log_level(LogLevel::Info, "Config file updated");
+}
+
+fn cat_config() {
+    change_work_dir(&utils::env::get_nyx_env_var());
+    let config_path = ".nxfs/config.toml";
+    if !fs::exists(config_path).expect("Failed to check if the configuration path exist") {
+        log_from_log_level(
+            LogLevel::Error,
+            "Config file path doesn't exit. Check if the configuration file exist",
+        );
+    }
+    let cat = Command::new("cat")
+        .arg(config_path)
+        .stdout(Stdio::inherit())
+        .output()
+        .expect("Failed to execute cat command");
+
+    println!("{}", String::from_utf8_lossy(&cat.stdout));
 }

--- a/src/nxfs/config.rs
+++ b/src/nxfs/config.rs
@@ -1,11 +1,12 @@
 use std::{fs::File, io::Write, process::exit};
 
 use crate::utils;
+use crate::utils::editor::open_new_editor;
 use crate::utils::log::log_from_log_level;
 use lrncore::path::change_work_dir;
 use lrncore::usage_exit::command_usage;
 use serde::{Deserialize, Serialize};
-use std::env;
+use std::{env, fs};
 use std::fmt::Debug;
 use toml::de::Error as toml_error;
 
@@ -15,6 +16,8 @@ Usage: nyx config [subcommand] [arguments] [options]
 
 Subcommands:
     init         Initialize the config file
+    update       Update the config file
+    cat          Cat the config file content
 
 
 Options:
@@ -120,6 +123,7 @@ pub fn config_command() {
     }
     match args[2].as_str() {
         "init" => init_config(),
+        "update" => update_config(),
 
         _ => {
             command_usage(&config_help());
@@ -195,4 +199,14 @@ pub fn parse_config_file() -> Result<Config, toml_error> {
         }
     };
     Ok(config)
+}
+
+fn update_config() {
+    change_work_dir(&utils::env::get_nyx_env_var());
+    let config_path = ".nxfs/config.toml";
+    if !fs::exists(config_path).expect("Failed to check if the configuration path exist") {
+        log_from_log_level(LogLevel::Error, "Config file path doesn't exit. Check if the configuration file exist");
+    }
+    open_new_editor(config_path);
+    log_from_log_level(LogLevel::Info, "Config file updated");
 }

--- a/src/nxfs/config.rs
+++ b/src/nxfs/config.rs
@@ -209,10 +209,10 @@ pub fn parse_config_file() -> Result<Config, toml_error> {
 fn update_config() {
     change_work_dir(&utils::env::get_nyx_env_var());
     let config_path = ".nxfs/config.toml";
-    if !fs::exists(config_path).expect("Failed to check if the configuration path exist") {
+    if !fs::exists(config_path).expect("Failed to check if the configuration path exists") {
         log_from_log_level(
             LogLevel::Error,
-            "Config file path doesn't exit. Check if the configuration file exist",
+            "Config file path doesn't exist. Check if the configuration file exists",
         );
         exit(1);
     }

--- a/src/nxfs/config.rs
+++ b/src/nxfs/config.rs
@@ -214,6 +214,7 @@ fn update_config() {
             LogLevel::Error,
             "Config file path doesn't exit. Check if the configuration file exist",
         );
+        exit(1);
     }
     open_new_editor(config_path);
     log_from_log_level(LogLevel::Info, "Config file updated");
@@ -227,12 +228,12 @@ fn cat_config() {
             LogLevel::Error,
             "Config file path doesn't exit. Check if the configuration file exist",
         );
+        exit(1);
     }
     let cat = Command::new("cat")
         .arg(config_path)
         .stdout(Stdio::inherit())
         .output()
         .expect("Failed to execute cat command");
-
     println!("{}", String::from_utf8_lossy(&cat.stdout));
 }

--- a/src/utils/editor.rs
+++ b/src/utils/editor.rs
@@ -91,3 +91,21 @@ pub fn update_editor(content: NXPContent) -> Vec<u8> {
         bincode::serialize(&update_content).expect("Failed to serialize updated content struct");
     buffer
 }
+
+pub fn open_new_editor(path: &str) {
+    change_work_dir(&get_nyx_env_var());
+    let editor: String = match nxfs::config::parse_config_file() {
+        Ok(c) => c.behavior.default_editor,
+        Err(e) => {
+            log::log_from_log_level(
+                LogLevel::Error,
+                &format!("Failed to parse config file: {}", e),
+            );
+            "vim".to_owned()
+        }
+    };
+    Command::new(editor)
+        .arg(path)
+        .status()
+        .expect("Something went wrong");
+}


### PR DESCRIPTION
This pull request introduces two new subcommands (`update` and `cat`) to the `nyx config` command, along with their corresponding implementations and utility functions. It also includes minor code improvements for better readability and error handling.

### New Features:

* Added the `update` subcommand to allow users to update the configuration file using their default editor. The implementation includes error handling for missing configuration files and uses the new `open_new_editor` utility function to open the file. (`src/nxfs/config.rs`, [[1]](diffhunk://#diff-5238a0f3ff9ef330958ecc67a6d8fc85779e5d5d46bbcc077af6e053b4cb8d23R20-R21) [[2]](diffhunk://#diff-5238a0f3ff9ef330958ecc67a6d8fc85779e5d5d46bbcc077af6e053b4cb8d23R127-R128) [[3]](diffhunk://#diff-5238a0f3ff9ef330958ecc67a6d8fc85779e5d5d46bbcc077af6e053b4cb8d23L193-R239)
* Added the `cat` subcommand to display the contents of the configuration file. This uses the `cat` command-line utility and includes error handling for missing configuration files. (`src/nxfs/config.rs`, [[1]](diffhunk://#diff-5238a0f3ff9ef330958ecc67a6d8fc85779e5d5d46bbcc077af6e053b4cb8d23R20-R21) [[2]](diffhunk://#diff-5238a0f3ff9ef330958ecc67a6d8fc85779e5d5d46bbcc077af6e053b4cb8d23R127-R128) [[3]](diffhunk://#diff-5238a0f3ff9ef330958ecc67a6d8fc85779e5d5d46bbcc077af6e053b4cb8d23L193-R239)

### Utility Enhancements:

* Introduced the `open_new_editor` function in `src/utils/editor.rs`, which opens a file in the user's default editor as specified in the configuration file. If the configuration file cannot be parsed, it defaults to `vim`. (`src/utils/editor.rs`, [src/utils/editor.rsR94-R111](diffhunk://#diff-fa36e75d8dc870cb21a5cb076beeff1a64fa35158f0172806033ed3ce7a9b9bdR94-R111))

### Code Improvements:

* Improved formatting of error messages in the `parse_config_file` function for better readability. (`src/nxfs/config.rs`, [src/nxfs/config.rsL193-R239](diffhunk://#diff-5238a0f3ff9ef330958ecc67a6d8fc85779e5d5d46bbcc077af6e053b4cb8d23L193-R239))
* Refactored imports in `src/nxfs/config.rs` to group related modules and remove unused imports. (`src/nxfs/config.rs`, [src/nxfs/config.rsR1-R11](diffhunk://#diff-5238a0f3ff9ef330958ecc67a6d8fc85779e5d5d46bbcc077af6e053b4cb8d23R1-R11))