### PR TITLE
111 add command to copy project location to paperclip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "nyx"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyx"
-version = "2.5.0"
+version = "2.6.0"
 edition = "2021"
 authors = ["Elouan DA COSTA PEIXOTO <elouandacostapeixoto@gmail.com>"]
 description = "A CLI tool for managing your projects."

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod hello;
 // Current version of NYX
 // if modified and then running update command it will replace
 // your current nyx installation with the newer version
-const VERSION: &str = "2.5.0";
+const VERSION: &str = "2.6.0";
 #[derive(Debug, Clone)]
 enum Commands {
     Init,

--- a/src/projects/copy/mod.rs
+++ b/src/projects/copy/mod.rs
@@ -65,10 +65,11 @@ fn copy_path() {
     let pbcopy = Command::new("pbcopy")
         .stdin(Stdio::piped())
         .spawn()
-        .expect("Failed to execute pbcopy command");
-    let echo = Command::new("echo")
+        .expect("Failed to spawn pbcopy command");
+    Command::new("echo")
         .arg(project_content.location)
         .stdout(pbcopy.stdin.unwrap())
         .output()
         .expect("Failed to execute echo command");
+    log_from_log_level(LogLevel::Info, "Project path copied in clipboard");
 }

--- a/src/projects/copy/mod.rs
+++ b/src/projects/copy/mod.rs
@@ -32,17 +32,23 @@ Options:
 pub fn copy_command() {
     change_work_dir(&get_nyx_env_var());
     let args: Vec<String> = env::args().collect();
-    if args.len() > 1 && (args[1] == "-h" || args[1] == "--help") {
+    if args.len() <= 3 {
         command_usage(&copy_help());
         return;
     }
-    if let Some(arg) = args.get(1) {
+    if args.len() > 1 && (args[3] == "-h" || args[3] == "--help") {
+        command_usage(&copy_help());
+        return;
+    }
+
+    if let Some(arg) = args.get(3) {
         let get_project = get_project_content();
         match arg.as_str().trim() {
             "path" => copy_field(get_project.location),
             "repo" => copy_field(get_project.repository),
             _ => {
-                copy_field(get_project.location);
+                println!("Unknown command");
+                command_usage(&copy_help());
             }
         }
     }

--- a/src/projects/copy/mod.rs
+++ b/src/projects/copy/mod.rs
@@ -1,8 +1,18 @@
-use std::{env, process::exit};
+use std::{
+    env,
+    process::{exit, Command, Stdio},
+};
 
 use lrncore::path::change_work_dir;
 
-use crate::{nxfs::{config::LogLevel, nxp::{self, NXPContent, NXPHeader, NXP}, nxs::{self, ProjectEntry}}, utils::{self, env::get_nyx_env_var, log::log_from_log_level}};
+use crate::{
+    nxfs::{
+        config::LogLevel,
+        nxp::{self, NXPContent, NXPHeader, NXP},
+        nxs::{self, ProjectEntry},
+    },
+    utils::{self, env::get_nyx_env_var, log::log_from_log_level},
+};
 
 pub fn copy_command() {
     change_work_dir(&get_nyx_env_var());
@@ -23,7 +33,7 @@ fn copy_path() {
         "Enter project name:".to_string(),
         "Error with the project name referred".to_string(),
     );
-    let project_hash: [u8;11];
+    let project_hash: [u8; 11];
     if let Some(pos) = projects.iter().position(|app| app.project_name == app_name) {
         log_from_log_level(LogLevel::Info, "Project found");
         let app = projects.remove(pos);
@@ -52,5 +62,13 @@ fn copy_path() {
     let hash = String::from_utf8_lossy(&project_hash);
     nxp::parse_nxp_file(&format!(".nxfs/projects/{}/content", &hash), &mut nxp);
     let project_content: NXPContent = nxp.content;
-    println!("debug: {:?}", project_content.location);
+    let pbcopy = Command::new("pbcopy")
+        .stdin(Stdio::piped())
+        .spawn()
+        .expect("Failed to execute pbcopy command");
+    let echo = Command::new("echo")
+        .arg(project_content.location)
+        .stdout(pbcopy.stdin.unwrap())
+        .output()
+        .expect("Failed to execute echo command");
 }

--- a/src/projects/copy/mod.rs
+++ b/src/projects/copy/mod.rs
@@ -47,7 +47,7 @@ pub fn copy_command() {
             "path" => copy_field(get_project.location),
             "repo" => copy_field(get_project.repository),
             _ => {
-                println!("Unknown command");
+                log_from_log_level(LogLevel::Error, "Unknown copy command");
                 command_usage(&copy_help());
             }
         }

--- a/src/projects/copy/mod.rs
+++ b/src/projects/copy/mod.rs
@@ -1,0 +1,56 @@
+use std::{env, process::exit};
+
+use lrncore::path::change_work_dir;
+
+use crate::{nxfs::{config::LogLevel, nxp::{self, NXPContent, NXPHeader, NXP}, nxs::{self, ProjectEntry}}, utils::{self, env::get_nyx_env_var, log::log_from_log_level}};
+
+pub fn copy_command() {
+    change_work_dir(&get_nyx_env_var());
+    let args: Vec<String> = env::args().collect();
+    if let Some(arg) = args.iter().last() {
+        match arg.as_str().trim() {
+            "path" => copy_path(),
+            "" => todo!(),
+            _ => {}
+        }
+    }
+}
+
+fn copy_path() {
+    let mut projects = nxs::get_all_project();
+    inquire::set_global_render_config(utils::get_render_config());
+    let app_name = utils::prompt_message(
+        "Enter project name:".to_string(),
+        "Error with the project name referred".to_string(),
+    );
+    let project_hash: [u8;11];
+    if let Some(pos) = projects.iter().position(|app| app.project_name == app_name) {
+        log_from_log_level(LogLevel::Info, "Project found");
+        let app = projects.remove(pos);
+        project_hash = app.project_hash;
+    } else {
+        log_from_log_level(LogLevel::Error, "Project not found");
+        exit(1);
+    }
+    let mut nxp: NXP = NXP {
+        header: NXPHeader {
+            magic_number: [0; 4],
+            format_version: [0; 6],
+            project_id: [0; 11],
+            project_size: 0,
+            reserved: 0,
+        },
+        content: NXPContent {
+            name: String::new(),
+            tech: String::new(),
+            location: String::new(),
+            repository: String::new(),
+            github_project: String::new(),
+            version: String::new(),
+        },
+    };
+    let hash = String::from_utf8_lossy(&project_hash);
+    nxp::parse_nxp_file(&format!(".nxfs/projects/{}/content", &hash), &mut nxp);
+    let project_content: NXPContent = nxp.content;
+    println!("debug: {:?}", project_content.location);
+}

--- a/src/projects/copy/mod.rs
+++ b/src/projects/copy/mod.rs
@@ -3,30 +3,64 @@ use std::{
     process::{exit, Command, Stdio},
 };
 
-use lrncore::path::change_work_dir;
+use lrncore::{path::change_work_dir, usage_exit::command_usage};
 
 use crate::{
     nxfs::{
         config::LogLevel,
         nxp::{self, NXPContent, NXPHeader, NXP},
-        nxs::{self, ProjectEntry},
+        nxs::{self},
     },
     utils::{self, env::get_nyx_env_var, log::log_from_log_level},
 };
 
+pub fn copy_help() -> String {
+    let usage = r"
+Usage: copy [subcommand] [arguments] [options]
+
+Subcommands:
+    path        Copy the path of specified project
+    repo        Copy the repository url of specified project
+
+Options:
+    -h, --help      Show this help message
+    ";
+
+    usage.to_string()
+}
+
 pub fn copy_command() {
     change_work_dir(&get_nyx_env_var());
     let args: Vec<String> = env::args().collect();
+    if args.last().unwrap() == "-h" || args.last().unwrap() == "--help" {
+        command_usage(&copy_help());
+    }
     if let Some(arg) = args.iter().last() {
+        let get_project = get_project_content();
         match arg.as_str().trim() {
-            "path" => copy_path(),
-            "" => todo!(),
-            _ => {}
+            "path" => copy_field(get_project.location),
+            "repo" => copy_field(get_project.repository),
+            _ => {
+                copy_field(get_project.location);
+            }
         }
     }
 }
 
-fn copy_path() {
+fn copy_field(param: String) {
+    let pbcopy = Command::new("pbcopy")
+        .stdin(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn pbcopy command");
+    Command::new("echo")
+        .arg(param)
+        .stdout(pbcopy.stdin.unwrap())
+        .output()
+        .expect("Failed to execute echo command");
+    log_from_log_level(LogLevel::Info, "Project field copied in clipboard");
+}
+
+fn get_project_content() -> NXPContent {
     let mut projects = nxs::get_all_project();
     inquire::set_global_render_config(utils::get_render_config());
     let app_name = utils::prompt_message(
@@ -62,14 +96,5 @@ fn copy_path() {
     let hash = String::from_utf8_lossy(&project_hash);
     nxp::parse_nxp_file(&format!(".nxfs/projects/{}/content", &hash), &mut nxp);
     let project_content: NXPContent = nxp.content;
-    let pbcopy = Command::new("pbcopy")
-        .stdin(Stdio::piped())
-        .spawn()
-        .expect("Failed to spawn pbcopy command");
-    Command::new("echo")
-        .arg(project_content.location)
-        .stdout(pbcopy.stdin.unwrap())
-        .output()
-        .expect("Failed to execute echo command");
-    log_from_log_level(LogLevel::Info, "Project path copied in clipboard");
+    project_content
 }

--- a/src/projects/copy/mod.rs
+++ b/src/projects/copy/mod.rs
@@ -32,10 +32,11 @@ Options:
 pub fn copy_command() {
     change_work_dir(&get_nyx_env_var());
     let args: Vec<String> = env::args().collect();
-    if args.last().unwrap() == "-h" || args.last().unwrap() == "--help" {
+    if args.len() > 1 && (args[1] == "-h" || args[1] == "--help") {
         command_usage(&copy_help());
+        return;
     }
-    if let Some(arg) = args.iter().last() {
+    if let Some(arg) = args.get(1) {
         let get_project = get_project_content();
         match arg.as_str().trim() {
             "path" => copy_field(get_project.location),

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -5,6 +5,7 @@ use std::{fs, process::exit};
 pub mod list;
 mod templates;
 pub mod update;
+use copy::copy_command;
 use delete::select_remove_project;
 use list::{add_existing_project_to_list, list_projects};
 use serde::{Deserialize, Serialize};
@@ -18,6 +19,7 @@ use lrncore::usage_exit::command_usage;
 use nxfs::{nxp, nxs};
 pub mod open;
 pub mod todo;
+mod copy;
 use open::open_editor;
 
 pub fn project_help() -> String {
@@ -32,6 +34,7 @@ Subcommands:
     delete      Remove a project from the list
     update      Update project properties
     todo        Manage project todos
+    copy        Copy a field of a specified project in clipboard
 
 Options:
     -h, --help      Show this help message
@@ -94,6 +97,7 @@ pub fn project_command() {
         "delete" => select_remove_project(),
         "update" => update_project_properties(),
         "todo" => choose_todo(),
+        "copy" => copy_command(),
         _ => {
             command_usage(&project_help());
         }

--- a/src/projects/update/mod.rs
+++ b/src/projects/update/mod.rs
@@ -71,7 +71,7 @@ pub fn update_project_properties() {
         project_size: 0,
     };
     if let Some(pos) = projects.iter().position(|app| app.project_name == app_name) {
-        println!("Project found");
+        log_from_log_level(LogLevel::Info, "Project found");
         let app = projects.remove(pos);
         current_project.project_hash = app.project_hash.clone();
         current_project.project_name = app.project_name.clone();

--- a/src/utils/log.rs
+++ b/src/utils/log.rs
@@ -1,3 +1,5 @@
+use std::process::exit;
+
 use lrncore::logs;
 
 use crate::nxfs::{self, config::LogLevel};
@@ -8,7 +10,10 @@ pub fn log_from_log_level(log_level: LogLevel, log_msg: &str) {
 
     if log_level <= config_log_level {
         match log_level {
-            LogLevel::Error => logs::time_error_log(log_msg),
+            LogLevel::Error => {
+                logs::time_error_log(log_msg);
+                exit(1)
+            }
             LogLevel::Warn => logs::warning_log(log_msg),
             LogLevel::Info => logs::info_log(log_msg),
             LogLevel::Debug => todo!(),


### PR DESCRIPTION
This pull request introduces a new `copy` command to the project management CLI tool, updates the version to `2.6.0`, and improves logging functionality. Below is a summary of the most important changes grouped by theme.

### New `copy` Command:

* Added a new `copy` module in `src/projects/copy/mod.rs` to implement the `copy` command, which allows users to copy project fields (e.g., path or repository URL) to the clipboard. This includes helper functions like `copy_help`, `copy_command`, `copy_field`, and `get_project_content`.
* Integrated the `copy` command into the project management CLI by updating `src/projects/mod.rs` to include the `copy` module, add the `copy` subcommand to the help message, and handle the command in `project_command()`. [[1]](diffhunk://#diff-f8d3640f42becee8479e02f47a15638ab9c484aecf395a2d874b282e66b9293eR8) [[2]](diffhunk://#diff-f8d3640f42becee8479e02f47a15638ab9c484aecf395a2d874b282e66b9293eR22) [[3]](diffhunk://#diff-f8d3640f42becee8479e02f47a15638ab9c484aecf395a2d874b282e66b9293eR37) [[4]](diffhunk://#diff-f8d3640f42becee8479e02f47a15638ab9c484aecf395a2d874b282e66b9293eR100)

### Version Update:

* Updated the project version from `2.5.0` to `2.6.0` in `Cargo.toml` and `src/main.rs` to reflect the new release. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL19-R19)

### Logging Enhancements:

* Enhanced logging by replacing `println!` with `log_from_log_level` in `src/projects/update/mod.rs` for better log consistency.
* Modified `log_from_log_level` in `src/utils/log.rs` to exit the process when logging an error, ensuring critical issues halt execution.

These changes collectively improve the functionality and robustness of the CLI tool.