### PR TITLE
124 add nyx logs folder size to hello command

### DIFF
--- a/src/hello/mod.rs
+++ b/src/hello/mod.rs
@@ -106,10 +106,15 @@ fn hello() {
         "\tProjects directory size: {}",
         helper::folder_size(&nxfs_projects_path)
     );
-    let nxfs_temp_path = nyx_path + "/.nxfs/tmp/";
+    let nxfs_temp_path = nyx_path.clone() + "/.nxfs/tmp/";
     print!(
         "\tTemp directory size: {}",
         helper::folder_size(&nxfs_temp_path)
+    );
+    let nxfs_log_path = nyx_path + "/.nxfs/logs/";
+    print!(
+        "\tLogs directory size: {}",
+        helper::folder_size(&nxfs_log_path)
     );
     println!(
         "\tNumber of projects: {}",

--- a/src/hello/mod.rs
+++ b/src/hello/mod.rs
@@ -40,6 +40,7 @@ pub fn hello_command() {
     }
 }
 
+/// Hello function printing all system information useful for user
 fn hello() {
     let user_name: String = nxfs::config::parse_config_file()
         .expect("Failed to get config file")


### PR DESCRIPTION
This pull request enhances the `hello` command in `src/hello/mod.rs` by improving functionality and code clarity. The most important changes include adding a new comment to describe the purpose of the `hello` function, introducing a new log directory size calculation, and using `clone()` to avoid ownership issues.

### Improvements to functionality:
* Added the calculation and display of the logs directory size (`nxfs_log_path`) in the `hello` function, providing additional system information to the user.

### Code clarity and safety:
* Added a descriptive comment to the `hello` function to explain its purpose, making the code more understandable for future developers.
* Used `nyx_path.clone()` instead of `nyx_path` when constructing the temporary directory path (`nxfs_temp_path`) to avoid ownership issues and ensure safer code.