### PR TITLE
116 fix project list add version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "nyx"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyx"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2021"
 authors = ["Elouan DA COSTA PEIXOTO <elouandacostapeixoto@gmail.com>"]
 description = "A CLI tool for managing your projects."

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod hello;
 // Current version of NYX
 // if modified and then running update command it will replace
 // your current nyx installation with the newer version
-const VERSION: &str = "2.6.0";
+const VERSION: &str = "2.6.1";
 #[derive(Debug, Clone)]
 enum Commands {
     Init,

--- a/src/nxfs/nxp.rs
+++ b/src/nxfs/nxp.rs
@@ -60,23 +60,23 @@ pub struct NXPContentShort {
     pub version: String,
 }
 
-// create a new NXP file to store project data
+// Create a new NXP file to store project data
 pub fn create_new_nxp(content: NXPContent) {
     lrncore::path::change_work_dir(&utils::env::get_nyx_env_var());
     // hash
     let mut new_hash = Sha1::new();
-    new_hash.update(content.name.to_owned());
+    new_hash.update(&content.name);
     let hash_result = new_hash.finalize();
     let folder_hash = format!("{:#x}", hash_result);
     let (file_hash, _) = folder_hash.split_at(11);
     // content
     let content: NXPContent = NXPContent {
-        name: format!("{}", content.name),
-        tech: format!("{}", content.tech),
-        location: format!("{}", content.location),
-        repository: format!("{}", content.repository),
-        github_project: format!("{}", content.github_project),
-        version: format!("{}", "0.1.0"),
+        name: content.name.to_string(),
+        tech: content.tech.to_string(),
+        location: content.location.to_string(),
+        repository: content.repository.to_string(),
+        github_project: content.github_project.to_string(),
+        version: content.version.to_string(),
     };
     let content_buff = bincode::serialize(&content).expect("Failed to serialize content buffer");
     // header
@@ -146,11 +146,11 @@ pub fn create_new_nxp(content: NXPContent) {
 /// Arguments:
 ///
 /// * `path`: The `path` parameter in the `parse_nxp_file` function represents the file path to the NXP
-/// file that you want to parse and extract information from. This function reads the contents of the
-/// specified NXP file, extracts the header and project content, and then populates the provided `N
+///   file that you want to parse and extract information from. This function reads the contents of the
+///   specified NXP file, extracts the header and project content, and then populates the provided `N
 /// * `nxp_ref`: The `nxp_ref` parameter in the `parse_nxp_file` function is a mutable reference to an
-/// instance of the `NXP` struct. This parameter allows the function to update the content of the `NXP`
-/// struct that is passed in by the caller. By using a mutable reference
+///   instance of the `NXP` struct. This parameter allows the function to update the content of the `NXP`
+///   struct that is passed in by the caller. By using a mutable reference
 pub fn parse_nxp_file(path: &str, nxp_ref: &mut NXP) {
     lrncore::path::change_work_dir(&utils::env::get_nyx_env_var());
     let file = match File::open(path) {
@@ -186,7 +186,7 @@ pub fn parse_nxp_file(path: &str, nxp_ref: &mut NXP) {
     let project_content: NXPContent =
         bincode::deserialize(project_content_bytes).expect("Failed to deserialize project content");
     let nxp: NXP = NXP {
-        header: header,
+        header,
         content: project_content,
     };
     nxp_ref.header = nxp.header;


### PR DESCRIPTION
This pull request includes a version bump for the `nyx` CLI tool and several code improvements in `src/nxfs/nxp.rs`. The changes include updating the version number, improving code readability, and simplifying expressions.

### Version Update:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3): Updated the package version from `2.6.0` to `2.6.1`.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL19-R19): Updated the `VERSION` constant to reflect the new version `2.6.1`.

### Code Improvements:
* `src/nxfs/nxp.rs`:
  - Improved readability by using `.to_string()` instead of `format!` for converting fields in the `create_new_nxp` function.
  - Simplified struct initialization in the `parse_nxp_file` function by removing redundant variable names.
### Error fix:
  - [`src/nxfs/nxp.rs`] Fix error when creating new NXP, it doesn't take the version field. 