### PR TITLE
106 improve exit code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "nyx"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "nyx"
-version = "2.6.2"
+version = "2.6.3"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyx"
-version = "2.6.2"
+version = "2.6.3"
 edition = "2021"
 authors = ["Elouan DA COSTA PEIXOTO <elouandacostapeixoto@gmail.com>"]
 description = "A CLI tool for managing your projects."

--- a/README.md
+++ b/README.md
@@ -10,3 +10,40 @@ NYX uses a unique file system called NXFS (Nyx File System). NXFS works using a 
 - nxp: a unique file per project. Containing all projects informations.
 
 They are unique binary file format using a strict defined structure. Using a header and a content.
+
+## Possible errors
+
+# Exit Codes
+
+## 💡 Principles:
+- **0**: Success.
+- **1-2**: General errors.
+- **3-9**: Argument and command errors.
+- **10-29**: Execution errors (files, access).
+- **30-49**: System or environment issues.
+- **50+**: Nyx-specific errors.
+
+| Exit Code| Description                            | Example Use                                          |
+|----------|----------------------------------------|------------------------------------------------------|
+| **0**    | Success                                | Command executed successfully.                       |
+| **1**    | General error                          | Undefined or uncategorized error.                    |
+| **2**    | Misuse of shell builtins               | Syntax error or incorrect usage.                     |
+| **3**    | Invalid argument                       | Unrecognized or incorrectly formatted argument.      |
+| **4**    | Missing argument                       | An expected argument is missing.                     |
+| **5**    | Unsupported command                    | The specified command or subcommand is not supported.|
+| **6**    | Subcommand failure                     | A subcommand called by Nyx has failed.               |
+| **7**    | Command conflict                       | Conflict between multiple options or commands.       |
+| **10**   | File not found                         | The specified file or project does not exist.        |
+| **11**   | Permission denied                      | Unable to access or modify a file.                   |
+| **12**   | File system error                      | Error during file read or write.                     |
+| **13**   | Invalid file format                    | File is unreadable or corrupted.                     |
+| **20**   | Missing environment dependency         | A required tool or binary is missing (e.g., `git`, `pbcopy`). |
+| **21**   | Incompatible environment               | Rust version or another component is incorrect.      |
+| **30**   | Configuration error                    | Configuration file is unreadable or malformed.       |
+| **31**   | Inconsistent state                     | File or directory in an unexpected state.            |
+| **40**   | Network error                          | Failed to reach an external resource.                |
+| **50**   | Nyx-specific error (generic)           | Internal tool error (e.g., project parsing failure). |
+| **51**   | NXFS error                             | Error related to the Nyx File System.                |
+| **52**   | TUI error                              | Issue with interactive display or UI rendering.      |
+| **60**   | Health check failed                    | An environment check has failed.                     |
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod hello;
 // Current version of NYX
 // if modified and then running update command it will replace
 // your current nyx installation with the newer version
-const VERSION: &str = "2.6.2";
+const VERSION: &str = "2.6.3";
 #[derive(Debug, Clone)]
 enum Commands {
     Init,

--- a/src/nxfs/config.rs
+++ b/src/nxfs/config.rs
@@ -182,7 +182,7 @@ fn init_config() {
                 LogLevel::Error,
                 &format!("Failed to write the config file: {}", e),
             );
-            exit(1);
+            exit(50);
         }
     };
     log_from_log_level(LogLevel::Info, "Successfully initialized nyx config file!");
@@ -214,7 +214,7 @@ fn update_config() {
             LogLevel::Error,
             "Config file path doesn't exist. Check if the configuration file exists",
         );
-        exit(1);
+        exit(50);
     }
     open_new_editor(config_path);
     log_from_log_level(LogLevel::Info, "Config file updated");
@@ -228,7 +228,7 @@ fn cat_config() {
             LogLevel::Error,
             "Config file path doesn't exist. Check if the configuration file exists",
         );
-        exit(1);
+        exit(50);
     }
     let cat = Command::new("cat")
         .arg(config_path)

--- a/src/projects/copy/mod.rs
+++ b/src/projects/copy/mod.rs
@@ -81,7 +81,7 @@ fn get_project_content() -> NXPContent {
         project_hash = app.project_hash;
     } else {
         log_from_log_level(LogLevel::Error, "Project not found");
-        exit(1);
+        exit(10);
     }
     let mut nxp: NXP = NXP {
         header: NXPHeader {

--- a/src/projects/list/mod.rs
+++ b/src/projects/list/mod.rs
@@ -140,7 +140,7 @@ fn create_repo_add_to_list(tech: &str) {
     let user_github_url = config.git.profile_url;
     if user_github_url.is_empty() {
         log::log_from_log_level(LogLevel::Error, "No github url was specified. Please enter one in config file.");
-        exit(1);
+        exit(4);
     }
     let repository: String = user_github_url + app_name;
     github_project = utils::prompt_message(

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -77,7 +77,7 @@ pub fn project_command() {
         "new" => {
             if args.len() <= 3 {
                 log::log_from_log_level(LogLevel::Error, "Enter a new project name");
-                exit(1);
+                exit(4);
             }
             let project_name = &args[3];
             new_project(project_name.to_string());

--- a/src/projects/open/mod.rs
+++ b/src/projects/open/mod.rs
@@ -56,7 +56,7 @@ pub fn open_editor(project: &str) {
         location = app.location;
     } else {
         log::log_from_log_level(LogLevel::Error, "Project not found");
-        exit(1);
+        exit(10);
     }
     let config = nxfs::config::parse_config_file().expect("Failed to parse nyx config file");
     let editor_var = config.behavior.default_editor;

--- a/src/projects/todo/helpers.rs
+++ b/src/projects/todo/helpers.rs
@@ -80,7 +80,7 @@ pub fn parse_todo_file(hash: &str) -> TodoFile {
         Ok(f) => f,
         Err(e) => {
             log::log_from_log_level(LogLevel::Error, &format!("Failed to open todo file: {}", e));
-            exit(1);
+            exit(51);
         }
     };
     // initialize TodoHeader size from structure and buffer
@@ -93,7 +93,7 @@ pub fn parse_todo_file(hash: &str) -> TodoFile {
             Ok(byte) => bytes_vec.push(byte),
             Err(e) => {
                 log::log_from_log_level(LogLevel::Error, &format!("Failed to read byte: {}", e));
-                exit(1)
+                exit(50)
             }
         }
     }

--- a/src/projects/todo/mod.rs
+++ b/src/projects/todo/mod.rs
@@ -169,7 +169,7 @@ fn update_todo_list() {
         project_hash = app.project_hash
     } else {
         log::log_from_log_level(LogLevel::Error, "Project not found");
-        exit(1);
+        exit(10);
     }
 
     let project_hash_str = String::from_utf8_lossy(&project_hash);
@@ -197,7 +197,7 @@ fn display_todo_list() {
         project_hash = app.project_hash
     } else {
         log::log_from_log_level(LogLevel::Error, "Project not found");
-        exit(1);
+        exit(10);
     }
     let project_hash_str = String::from_utf8_lossy(&project_hash);
     let todo: TodoFile = parse_todo_file(&project_hash_str);
@@ -225,7 +225,7 @@ fn prune_todo() {
         project_hash = app.project_hash
     } else {
         log::log_from_log_level(LogLevel::Error, "Project not found");
-        exit(1);
+        exit(10);
     }
     let project_hash_str = String::from_utf8_lossy(&project_hash);
 
@@ -271,7 +271,7 @@ fn remove_todo() {
         project_hash = app.project_hash;
     } else {
         log::log_from_log_level(LogLevel::Error, "Project not found");
-        exit(1);
+        exit(10);
     }
 
     let project_hash_str = String::from_utf8_lossy(&project_hash);

--- a/src/projects/update/mod.rs
+++ b/src/projects/update/mod.rs
@@ -78,7 +78,7 @@ pub fn update_project_properties() {
         current_project.project_size = app.project_size.clone();
     } else {
         log_from_log_level(LogLevel::Error, "Project not found");
-        exit(1);
+        exit(10);
     }
     let mut nxp: NXP = NXP {
         header: NXPHeader {

--- a/src/utils/fsys.rs
+++ b/src/utils/fsys.rs
@@ -26,14 +26,14 @@ pub fn create_dir(path: &str) {
 pub fn rm_command(path: String) {
     if path.is_empty() {
         log::log_from_log_level(LogLevel::Error, "Path is empty");
-        exit(1)
+        exit(4)
     }
 
     let forbidden_names = ["/", ".", ".."];
     let forbidden_patterns = ['*', '?', '&', ';', '|', '`'];
     if forbidden_names.contains(&path.as_str()) {
         log::log_from_log_level(LogLevel::Error, "Input contains forbidden names.");
-        exit(1)
+        exit(2)
     };
 
     if path.chars().any(|c| forbidden_patterns.contains(&c)) {
@@ -41,7 +41,7 @@ pub fn rm_command(path: String) {
             LogLevel::Error,
             "Input contains forbidden patterns (*, ?, &, ;, |, `).",
         );
-        exit(1)
+        exit(2)
     }
 
     let mut rm = Command::new("rm")
@@ -59,12 +59,12 @@ pub fn rm_command(path: String) {
                 "Error in the remove command. Check if you have the right to remove directories.",
             );
             println!("{}", line.unwrap());
-            exit(1);
+            exit(2);
         }
     }
     let wait_rm = rm.wait().expect("Failed to wait rm command");
     if !wait_rm.success() {
         log::log_from_log_level(LogLevel::Error, "Failed to execute rm command");
-        exit(1);
+        exit(6);
     }
 }


### PR DESCRIPTION
This pull request introduces a standardized exit code system for the Nyx project, replacing the generic `exit(1)` calls with specific exit codes to improve error handling and debugging. Additionally, the documentation has been updated to include a detailed explanation of these exit codes.

### Documentation Updates:
* Added a new section in `README.md` to document the standardized exit codes, including their categories and example usages.

### Code Changes for Standardized Exit Codes:
#### General Error Handling:
* Replaced `exit(1)` with specific exit codes across various functions to reflect the nature of the errors:
  - `exit(50)` for configuration-related errors in `src/nxfs/config.rs` (`init_config`, `update_config`, `cat_config`). [[1]](diffhunk://#diff-5238a0f3ff9ef330958ecc67a6d8fc85779e5d5d46bbcc077af6e053b4cb8d23L185-R185) [[2]](diffhunk://#diff-5238a0f3ff9ef330958ecc67a6d8fc85779e5d5d46bbcc077af6e053b4cb8d23L217-R217) [[3]](diffhunk://#diff-5238a0f3ff9ef330958ecc67a6d8fc85779e5d5d46bbcc077af6e053b4cb8d23L231-R231)
  - `exit(10)` for "Project not found" errors across multiple project-related functions. [[1]](diffhunk://#diff-9cb31d6fd7527dab2ae962611264faf328f5f41f655bbd1ea968e2d0a1e56403L84-R84) [[2]](diffhunk://#diff-32e0e0cc74c1c3e26b9a7b1315b34bb2200b4e1a5d3cba95f7cd63dbf28a0cecL59-R59) [[3]](diffhunk://#diff-06d2c4124cf4ede8bf7e8dbfc0d9ecf645f1968ebc304c4cd1708622e060a511L172-R172) [[4]](diffhunk://#diff-06d2c4124cf4ede8bf7e8dbfc0d9ecf645f1968ebc304c4cd1708622e060a511L200-R200) [[5]](diffhunk://#diff-06d2c4124cf4ede8bf7e8dbfc0d9ecf645f1968ebc304c4cd1708622e060a511L228-R228) [[6]](diffhunk://#diff-06d2c4124cf4ede8bf7e8dbfc0d9ecf645f1968ebc304c4cd1708622e060a511L274-R274) [[7]](diffhunk://#diff-8392019e39b2ce2bf5de6e1201eb0be083239ca5045e90caec33d278f1fec7cdL81-R81)

#### Argument and Command Errors:
* Updated functions to use `exit(4)` for missing or invalid arguments:
  - `create_repo_add_to_list` and `project_command` in `src/projects`. [[1]](diffhunk://#diff-e0b1eb902b29654a77b1ad7eb3ada10e2d843f5d1e3eef928fcba6fe62c72242L143-R143) [[2]](diffhunk://#diff-f8d3640f42becee8479e02f47a15638ab9c484aecf395a2d874b282e66b9293eL80-R80)
  - `rm_command` in `src/utils/fsys.rs` for empty paths or forbidden inputs.

#### File System and Nyx-Specific Errors:
* Introduced:
  - `exit(51)` for NXFS-specific errors in `parse_todo_file`.
  - `exit(50)` for generic Nyx-related errors in the same function.
  - `exit(6)` for failed `rm` command executions in `src/utils/fsys.rs`.