### PR TITLE
Fix panic on pbcopy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "nyx"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyx"
-version = "2.10.0"
+version = "2.10.1"
 edition = "2021"
 authors = ["Elouan DA COSTA PEIXOTO <elouandacostapeixoto@gmail.com>"]
 description = "A CLI tool for managing your projects."

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ mod hello;
 // Current version of NYX
 // if modified and then running update command it will replace
 // your current nyx installation with the newer version
-const VERSION: &str = "2.10.0";
+const VERSION: &str = "2.10.1";
 enum Commands {
     Init,
     CatNxs,

--- a/src/projects/copy/mod.rs
+++ b/src/projects/copy/mod.rs
@@ -59,15 +59,18 @@ fn copy_field(param: String) {
         .stdin(Stdio::piped())
         .spawn()
         .expect("Failed to spawn pbcopy command");
+    if let Some(mut stdin) = pbcopy.stdin.take() {
+        use std::io::Write;
+        stdin
+            .write_all(param.as_bytes())
+            .expect("Failed to write to pbcopy stdin");
+    } else {
+        log_from_log_level(LogLevel::Error, "Failed to open pbcopy stdin");
+    }
     let wait_pbcopy = pbcopy.wait().expect("Failed to wait pbcopy command");
     if !wait_pbcopy.success() {
         log_from_log_level(LogLevel::Error, "Failed to execute pbcopy command");
     }
-    Command::new("echo")
-        .arg(param)
-        .stdout(pbcopy.stdin.unwrap())
-        .output()
-        .expect("Failed to execute echo command");
     log_from_log_level(LogLevel::Info, "Project field copied in clipboard");
 }
 


### PR DESCRIPTION
This pull request updates the `copy_field` function in `src/projects/copy/mod.rs` to improve error handling and streamline the process of writing to the clipboard. The changes replace the use of the `echo` command with direct writing to the `pbcopy` process's stdin, ensuring better reliability and logging in case of errors.

### Key changes:

* **Improved error handling for `pbcopy` stdin:**
  - Added a check to ensure `pbcopy.stdin` is available before attempting to write. If unavailable, an error is logged using `log_from_log_level`.

* **Replaced `echo` command with direct stdin writing:**
  - Removed the use of `Command::new("echo")` to write to `pbcopy` and replaced it with a direct call to `stdin.write_all(param.as_bytes())`. This simplifies the process and reduces dependency on external commands.