### PR TITLE
Add config.toml file

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+[alias]     # command aliases
+b = "build"
+c = "check"
+t = "test"
+r = "run"
+rr = "run --release"
+w = "clippy -- -D warnings"
+recursive_example = "rr --example recursions"
+space_example = ["run", "--release", "--", "\"command list\""]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,3 +7,7 @@ rr = "run --release"
 w = "clippy -- -D warnings"
 recursive_example = "rr --example recursions"
 space_example = ["run", "--release", "--", "\"command list\""]
+
+[future-incompat-report]
+frequency = 'always' # when to display a notification about a future incompat report
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,0 @@
-CC = cargo
-
-clippy-Wall:
-	$(CC) clippy -- -D warnings


### PR DESCRIPTION
This pull request introduces enhancements to the Rust development workflow by adding command aliases in the `.cargo/config.toml` file and removing redundant Makefile targets. These changes streamline common tasks and eliminate duplication.

### Improvements to Rust development workflow:

* [`.cargo/config.toml`](diffhunk://#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268R1-R13): Added command aliases for frequently used `cargo` commands (e.g., `build`, `check`, `test`, `run`, `clippy`, etc.) and configured a `future-incompat-report` notification frequency. These aliases simplify the execution of common tasks.

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-L4): Removed the `clippy-Wall` target and the `CC` variable definition since the functionality is now covered by the new aliases in `.cargo/config.toml`. This reduces redundancy in the build configuration.