### PR TITLE
Add git pull to upgrade command

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,7 +1,9 @@
 use std::process::Command;
 
 use crate::env;
+use crate::nxfs::config::LogLevel;
 use crate::utils;
+use crate::utils::log::log_from_log_level;
 
 use lrncore::usage_exit::command_usage;
 
@@ -134,4 +136,15 @@ fn show_stash() {
         .output()
         .expect("Failed to call the git shortlog command");
     println!("{}", str::from_utf8(&list.stdout).unwrap());
+}
+
+pub fn git_pull() {
+    let mut pull = Command::new("git")
+        .arg("pull")
+        .spawn()
+        .expect("Failed to execute pull command");
+    let wait_pull = pull.wait().expect("Failed to wait pull command");
+    if !wait_pull.success() {
+        log_from_log_level(LogLevel::Error, "Failed to pull from remote repository");
+    }
 }

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -1,4 +1,4 @@
-use crate::utils;
+use crate::{git, utils};
 
 use colored::Colorize;
 use lrncore::path::change_work_dir;
@@ -8,6 +8,7 @@ use throbber::Throbber;
 /// Check if there's a new version of nyx and if so update the current one
 pub fn upgrade_bin() {
     change_work_dir(&utils::env::get_nyx_env_var());
+    git::git_pull();
     let nyx_art = utils::nyx_ascii_art();
     // throbber
     let mut building_throbber = Throbber::new()


### PR DESCRIPTION
This pull request introduces a new `git_pull` function to handle pulling updates from a remote repository and integrates it into the `upgrade_bin` function. It also includes minor adjustments to imports to accommodate the new functionality.

### New functionality:
* Added `git_pull` function in `src/git/mod.rs` to execute a `git pull` command and log an error if the pull operation fails.

### Integration:
* Updated the `upgrade_bin` function in `src/upgrade/mod.rs` to call the new `git_pull` function, ensuring the repository is updated before proceeding with the upgrade process.

### Import adjustments:
* Added imports for `LogLevel` and `log_from_log_level` in `src/git/mod.rs` to support logging in the `git_pull` function.
* Adjusted imports in `src/upgrade/mod.rs` to include the `git` module for accessing the new `git_pull` function.