### PR TITLE
Fix git pull and improve upgrade

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,4 +1,4 @@
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use crate::env;
 use crate::nxfs::config::LogLevel;
@@ -139,12 +139,15 @@ fn show_stash() {
 }
 
 pub fn git_pull() {
-    let mut pull = Command::new("git")
+    let pull = Command::new("git")
         .arg("pull")
+        .stdout(Stdio::piped())
         .spawn()
         .expect("Failed to execute pull command");
-    let wait_pull = pull.wait().expect("Failed to wait pull command");
-    if !wait_pull.success() {
+    let wait_pull = pull
+        .wait_with_output()
+        .expect("Failed to wait pull command");
+    if !wait_pull.status.success() {
         log_from_log_level(LogLevel::Error, "Failed to pull from remote repository");
     }
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -138,6 +138,7 @@ fn show_stash() {
     println!("{}", str::from_utf8(&list.stdout).unwrap());
 }
 
+/// Spawn git pull process
 pub fn git_pull() {
     let pull = Command::new("git")
         .arg("pull")

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -8,8 +8,8 @@ use throbber::Throbber;
 /// Check if there's a new version of nyx and if so update the current one
 pub fn upgrade_bin() {
     change_work_dir(&utils::env::get_nyx_env_var());
-    git::git_pull();
     let nyx_art = utils::nyx_ascii_art();
+    git::git_pull();
     // throbber
     let mut building_throbber = Throbber::new()
         .message("Building latest NYX binary...".to_owned())

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -9,7 +9,6 @@ use throbber::Throbber;
 pub fn upgrade_bin() {
     change_work_dir(&utils::env::get_nyx_env_var());
     let nyx_art = utils::nyx_ascii_art();
-    git::git_pull();
     // throbber
     let mut building_throbber = Throbber::new()
         .message("Building latest NYX binary...".to_owned())
@@ -18,6 +17,8 @@ pub fn upgrade_bin() {
         .message("Updating NYX...".to_owned())
         .frames(&throbber::ROTATE_F);
     println!("{}", nyx_art.truecolor(138, 43, 226));
+    println!("Pulling from remote repository...");
+    git::git_pull();
     building_throbber.start();
 
     // nyx version


### PR DESCRIPTION
This pull request introduces improvements to the `git_pull` function in `src/git/mod.rs` to enhance error handling and output management, along with minor adjustments to the `upgrade_bin` function in `src/upgrade/mod.rs` to reorder operations for better user feedback.

### Improvements to `git_pull` function:
* Modified the `git_pull` function to use `Stdio::piped()` for capturing output and replaced `wait()` with `wait_with_output()` to handle both the status and output of the command. This improves error handling and provides more flexibility for processing command output. (`src/git/mod.rs`, [src/git/mod.rsR141-R151](diffhunk://#diff-7ac34c894469017b7cb26b24ca0d9fa2aff0bf7bab890d88af71c2bffbe33674R141-R151))
* Updated imports to include `Stdio` from `std::process` to support the changes in `git_pull`. (`src/git/mod.rs`, [src/git/mod.rsL1-R1](diffhunk://#diff-7ac34c894469017b7cb26b24ca0d9fa2aff0bf7bab890d88af71c2bffbe33674L1-R1))

### Adjustments to `upgrade_bin` function:
* Reordered the `git_pull` call in `upgrade_bin` to execute before starting the throbber, ensuring that the repository pull process is clearly communicated to the user before the progress indicator begins. (`src/upgrade/mod.rs`, [src/upgrade/mod.rsR20-R21](diffhunk://#diff-6259dafb0af0e180990e2827dcac4bdba5a7c04c7d23055174fa025837f5bb74R20-R21))
* Removed and re-added the `git_pull` call in `upgrade_bin` with a new placement, aligning with the updated workflow. (`src/upgrade/mod.rs`, [src/upgrade/mod.rsL11](diffhunk://#diff-6259dafb0af0e180990e2827dcac4bdba5a7c04c7d23055174fa025837f5bb74L11))